### PR TITLE
Exports "getCleanUrl" utility

### DIFF
--- a/src/RequestInterceptor.ts
+++ b/src/RequestInterceptor.ts
@@ -1,0 +1,49 @@
+import { RequestMiddleware, ModuleOverride } from './glossary'
+import { overrideHttpModule } from './http/override'
+import { overrideXhrModule } from './XMLHttpRequest/override'
+
+const debug = require('debug')('root')
+
+export class RequestInterceptor {
+  private overrides: ReturnType<ModuleOverride>[]
+  private middleware: RequestMiddleware[]
+
+  constructor() {
+    this.middleware = []
+
+    debug('created new instance')
+
+    this.overrides = [
+      overrideHttpModule(this.applyMiddleware),
+      overrideXhrModule(this.applyMiddleware),
+    ]
+  }
+
+  /**
+   * Restores original HTTP/HTTPS/XHR instances.
+   */
+  public restore() {
+    debug('restore')
+    this.overrides.forEach((restore) => restore())
+  }
+
+  /**
+   * Applies given middleware to any intercepted request.
+   */
+  public use(middleware: RequestMiddleware) {
+    debug('use')
+    this.middleware.push(middleware)
+  }
+
+  private applyMiddleware: RequestMiddleware = async (req, ref) => {
+    debug('applyMiddleware', req)
+
+    for (let middleware of this.middleware) {
+      const res = await middleware(req, ref)
+
+      if (res) {
+        return res
+      }
+    }
+  }
+}

--- a/src/XMLHttpRequest/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -5,7 +5,7 @@
 import { flattenHeadersObject } from 'headers-utils'
 import { RequestMiddleware, InterceptedRequest } from '../../glossary'
 import { createEvent } from './createEvent'
-import { cleanUrl } from '../../utils/cleanUrl'
+import { getCleanUrl } from '../../utils/getCleanUrl'
 
 const debug = require('debug')('XHR')
 
@@ -184,13 +184,13 @@ export const createXMLHttpRequestOverride = (
         url = new URL(this.url, window.location.href)
       }
 
-      const cleanedUrl = cleanUrl(url, isAbsoluteUrl)
+      const cleanUrl = getCleanUrl(url, isAbsoluteUrl)
 
       debug('is absolute url?', isAbsoluteUrl)
-      debug('cleaned url:', cleanedUrl)
+      debug('cleaned url:', cleanUrl)
 
       const req: InterceptedRequest = {
-        url: cleanedUrl,
+        url: cleanUrl,
         method: this.method,
         query: url.searchParams,
         body: this.data,

--- a/src/http/ClientRequest/ClientRequestOverride.ts
+++ b/src/http/ClientRequest/ClientRequestOverride.ts
@@ -4,7 +4,7 @@ import http, { IncomingMessage, ClientRequest } from 'http'
 import { Socket } from './Socket'
 import { RequestMiddleware, InterceptedRequest } from '../../glossary'
 import { normalizeHttpRequestParams } from './normalizeHttpRequestParams'
-import { cleanUrl } from '../../utils/cleanUrl'
+import { getCleanUrl } from '../../utils/getCleanUrl'
 
 const debug = require('debug')('http:client-request')
 
@@ -75,7 +75,7 @@ export function createClientRequestOverrideClass(
       this.once('response', callback)
     }
 
-    const urlWithoutQuery = cleanUrl(url)
+    const urlWithoutQuery = getCleanUrl(url)
 
     debug('resolved clean URL:', urlWithoutQuery)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/* Typings */
 export {
   InterceptedRequest,
   MockedResponse,
@@ -5,4 +6,8 @@ export {
   ReturnedResponse,
 } from './glossary'
 
+/* Classes */
 export { RequestInterceptor } from './RequestInterceptor'
+
+/* Utils */
+export { getCleanUrl } from './utils/getCleanUrl'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,8 @@
-import {
-  RequestMiddleware,
-  ModuleOverride,
+export {
   InterceptedRequest,
   MockedResponse,
+  RequestMiddleware,
+  ReturnedResponse,
 } from './glossary'
-import { overrideHttpModule } from './http/override'
-import { overrideXhrModule } from './XMLHttpRequest/override'
 
-const debug = require('debug')('root')
-
-export class RequestInterceptor {
-  private overrides: ReturnType<ModuleOverride>[]
-  private middleware: RequestMiddleware[]
-
-  constructor() {
-    this.middleware = []
-
-    debug('created new instance')
-
-    this.overrides = [
-      overrideHttpModule(this.applyMiddleware),
-      overrideXhrModule(this.applyMiddleware),
-    ]
-  }
-
-  /**
-   * Restores original HTTP/HTTPS/XHR instances.
-   */
-  public restore() {
-    debug('restore')
-    this.overrides.forEach((restore) => restore())
-  }
-
-  /**
-   * Applies given middleware to any intercepted request.
-   */
-  public use(middleware: RequestMiddleware) {
-    debug('use')
-    this.middleware.push(middleware)
-  }
-
-  private applyMiddleware: RequestMiddleware = async (req, ref) => {
-    debug('applyMiddleware', req)
-
-    for (let middleware of this.middleware) {
-      const res = await middleware(req, ref)
-
-      if (res) {
-        return res
-      }
-    }
-  }
-}
-
-export { InterceptedRequest, MockedResponse }
+export { RequestInterceptor } from './RequestInterceptor'

--- a/src/utils/cleanUrl.ts
+++ b/src/utils/cleanUrl.ts
@@ -1,6 +1,0 @@
-/**
- * Strips query parameters and hashes from the given URL.
- */
-export function cleanUrl(url: URL, isAbsolute: boolean = true): string {
-  return [isAbsolute && url.origin, url.pathname].filter(Boolean).join('')
-}

--- a/src/utils/getCleanUrl.test.ts
+++ b/src/utils/getCleanUrl.test.ts
@@ -1,31 +1,31 @@
-import { cleanUrl } from './cleanUrl'
+import { getCleanUrl } from './getCleanUrl'
 
-describe('cleanUrl', () => {
+describe('getCleanUrl', () => {
   describe('given a URL without query parameters', () => {
     it('should return url href as-is', () => {
       const url = new URL('https://github.com')
-      expect(cleanUrl(url)).toEqual('https://github.com/')
+      expect(getCleanUrl(url)).toEqual('https://github.com/')
     })
   })
 
   describe('given a URL with query parameters', () => {
     it('should return url without parameters', () => {
       const url = new URL('https://github.com/mswjs/?userId=abc-123')
-      expect(cleanUrl(url)).toEqual('https://github.com/mswjs/')
+      expect(getCleanUrl(url)).toEqual('https://github.com/mswjs/')
     })
   })
 
   describe('given a URL with a hash', () => {
     it('should return a url without hash', () => {
       const url = new URL('https://github.com/mswjs/#hello-world')
-      expect(cleanUrl(url)).toEqual('https://github.com/mswjs/')
+      expect(getCleanUrl(url)).toEqual('https://github.com/mswjs/')
     })
   })
 
   describe('given an absolute URL ', () => {
     it('should return a clean relative URL', () => {
       const url = new URL('/login?query=value', 'https://github.com')
-      expect(cleanUrl(url, false)).toEqual('/login')
+      expect(getCleanUrl(url, false)).toEqual('/login')
     })
   })
 })

--- a/src/utils/getCleanUrl.ts
+++ b/src/utils/getCleanUrl.ts
@@ -1,0 +1,6 @@
+/**
+ * Removes query parameters and hashes from the given URL.
+ */
+export function getCleanUrl(url: URL, isAbsolute: boolean = true): string {
+  return [isAbsolute && url.origin, url.pathname].filter(Boolean).join('')
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -3,7 +3,7 @@ import http, { IncomingMessage, RequestOptions } from 'http'
 import nodeFetch, { Response, RequestInfo, RequestInit } from 'node-fetch'
 import { urlToOptions } from '../src/utils/urlToOptions'
 import { InterceptedRequest } from '../src/glossary'
-import { cleanUrl } from '../src/utils/cleanUrl'
+import { getCleanUrl } from '../src/utils/getCleanUrl'
 
 interface PromisifiedResponse {
   res: IncomingMessage
@@ -162,7 +162,7 @@ export function findRequest(
   url: string
 ): InterceptedRequest | undefined {
   const parsedUrl = new URL(url)
-  const resolvedUrl = cleanUrl(parsedUrl)
+  const resolvedUrl = getCleanUrl(parsedUrl)
 
   return pool.find((request) => {
     return request.method === method && request.url === resolvedUrl
@@ -174,7 +174,7 @@ export async function prepare(
   pool: InterceptedRequest[]
 ): Promise<InterceptedRequest | undefined> {
   const { url, options } = await promise
-  const resolvedUrl = cleanUrl(new URL(url))
+  const resolvedUrl = getCleanUrl(new URL(url))
 
   return findRequest(pool, options.method, resolvedUrl)
 }


### PR DESCRIPTION
## Motivation

`getCleanUrl` is also used in `msw` for the same purpose. This logic needs to be unified across libraries to guarantee stable behavior. 

## Changes

```js
import { getCleanUrl } from 'node-request-interceptor'
```