### PR TITLE
Returns a URL instance as "req.url" value

### DIFF
--- a/src/XMLHttpRequest/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -188,7 +188,6 @@ export const createXMLHttpRequestOverride = (
       const req: InterceptedRequest = {
         url,
         method: this.method,
-        query: url.searchParams,
         body: this.data,
         headers: this.requestHeaders,
       }

--- a/src/XMLHttpRequest/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -5,7 +5,6 @@
 import { flattenHeadersObject } from 'headers-utils'
 import { RequestMiddleware, InterceptedRequest } from '../../glossary'
 import { createEvent } from './createEvent'
-import { getCleanUrl } from '../../utils/getCleanUrl'
 
 const debug = require('debug')('XHR')
 
@@ -184,13 +183,10 @@ export const createXMLHttpRequestOverride = (
         url = new URL(this.url, window.location.href)
       }
 
-      const cleanUrl = getCleanUrl(url, isAbsoluteUrl)
-
       debug('is absolute url?', isAbsoluteUrl)
-      debug('cleaned url:', cleanUrl)
 
       const req: InterceptedRequest = {
-        url: cleanUrl,
+        url,
         method: this.method,
         query: url.searchParams,
         body: this.data,

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -5,7 +5,7 @@ export type ModuleOverride = (handler: RequestMiddleware) => () => void
 export type HttpRequestCallback = (res: IncomingMessage) => void
 
 export interface InterceptedRequest {
-  url: string
+  url: URL
   method: string
   headers?: Record<string, string | string[]>
   query: URLSearchParams

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -8,7 +8,6 @@ export interface InterceptedRequest {
   url: URL
   method: string
   headers?: Record<string, string | string[]>
-  query: URLSearchParams
   body?: string | undefined
 }
 

--- a/src/http/ClientRequest/ClientRequestOverride.ts
+++ b/src/http/ClientRequest/ClientRequestOverride.ts
@@ -121,7 +121,6 @@ export function createClientRequestOverrideClass(
         method: options.method || 'GET',
         headers: (options.headers as Record<string, string | string[]>) || {},
         body: requestBody,
-        query: url.searchParams,
       }
 
       debug('awaiting mocked response...')

--- a/src/http/ClientRequest/ClientRequestOverride.ts
+++ b/src/http/ClientRequest/ClientRequestOverride.ts
@@ -4,7 +4,6 @@ import http, { IncomingMessage, ClientRequest } from 'http'
 import { Socket } from './Socket'
 import { RequestMiddleware, InterceptedRequest } from '../../glossary'
 import { normalizeHttpRequestParams } from './normalizeHttpRequestParams'
-import { getCleanUrl } from '../../utils/getCleanUrl'
 
 const debug = require('debug')('http:client-request')
 
@@ -75,10 +74,6 @@ export function createClientRequestOverrideClass(
       this.once('response', callback)
     }
 
-    const urlWithoutQuery = getCleanUrl(url)
-
-    debug('resolved clean URL:', urlWithoutQuery)
-
     const emitError = (error: Error) => {
       process.nextTick(() => {
         this.emit('error', error)
@@ -122,7 +117,7 @@ export function createClientRequestOverrideClass(
       // Construct the intercepted request instance.
       // This request is what's exposed to the request middleware.
       const formattedRequest: InterceptedRequest = {
-        url: urlWithoutQuery,
+        url,
         method: options.method || 'GET',
         headers: (options.headers as Record<string, string | string[]>) || {},
         body: requestBody,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -162,10 +162,13 @@ export function findRequest(
   url: string
 ): InterceptedRequest | undefined {
   const parsedUrl = new URL(url)
-  const resolvedUrl = getCleanUrl(parsedUrl)
+  const expectedUrl = getCleanUrl(parsedUrl)
 
   return pool.find((request) => {
-    return request.method === method && request.url === resolvedUrl
+    const isMethodEqual = request.method === method
+    const isUrlEqual = getCleanUrl(request.url) === expectedUrl
+
+    return isMethodEqual && isUrlEqual
   })
 }
 
@@ -174,7 +177,5 @@ export async function prepare(
   pool: InterceptedRequest[]
 ): Promise<InterceptedRequest | undefined> {
   const { url, options } = await promise
-  const resolvedUrl = getCleanUrl(new URL(url))
-
-  return findRequest(pool, options.method, resolvedUrl)
+  return findRequest(pool, options.method, url)
 }

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
@@ -46,7 +46,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/get')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/get?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -82,7 +85,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/post')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/post?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -121,7 +127,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/put')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/put?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -156,7 +165,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/delete')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/delete?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -191,7 +203,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/patch')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/patch?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -228,7 +243,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/get')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/get?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -264,7 +282,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/post')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/post?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -303,7 +324,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/put')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/put?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -338,7 +362,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/delete')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/delete?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -373,7 +400,10 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/patch')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/patch?userId=123'
+        )
       })
 
       it('should access request method', () => {

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
@@ -57,7 +57,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -96,7 +96,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access request body', () => {
@@ -138,7 +138,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -176,7 +176,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -214,7 +214,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -254,7 +254,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -293,7 +293,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access request body', () => {
@@ -335,7 +335,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -373,7 +373,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -411,7 +411,7 @@ describe('XMLHttpRequest', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {

--- a/test/intercept/fetch/fetch.test.ts
+++ b/test/intercept/fetch/fetch.test.ts
@@ -60,7 +60,7 @@ describe('fetch', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access default request headers', () => {
@@ -104,7 +104,7 @@ describe('fetch', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access request body', () => {
@@ -151,7 +151,7 @@ describe('fetch', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access default request headers', () => {
@@ -194,7 +194,7 @@ describe('fetch', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access default request headers', () => {
@@ -241,7 +241,7 @@ describe('fetch', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access default request headers', () => {
@@ -285,7 +285,7 @@ describe('fetch', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access request body', () => {
@@ -332,7 +332,7 @@ describe('fetch', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access default request headers', () => {
@@ -375,7 +375,7 @@ describe('fetch', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access default request headers', () => {

--- a/test/intercept/fetch/fetch.test.ts
+++ b/test/intercept/fetch/fetch.test.ts
@@ -49,7 +49,10 @@ describe('fetch', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/get')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/get?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -90,7 +93,10 @@ describe('fetch', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/post')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/post?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -134,7 +140,10 @@ describe('fetch', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/put')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/put?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -174,7 +183,10 @@ describe('fetch', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/delete')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/delete?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -218,7 +230,10 @@ describe('fetch', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/get')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/get?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -259,7 +274,10 @@ describe('fetch', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/post')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/post?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -303,7 +321,10 @@ describe('fetch', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/put')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/put?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -343,7 +364,10 @@ describe('fetch', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/delete')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/delete?userId=123'
+        )
       })
 
       it('should access request method', () => {

--- a/test/intercept/http/http.get.test.ts
+++ b/test/intercept/http/http.get.test.ts
@@ -39,7 +39,10 @@ describe('http.get', () => {
     })
 
     it('should access request url', () => {
-      expect(request).toHaveProperty('url', 'http://httpbin.org/get')
+      expect(request?.url).toBeInstanceOf(URL)
+      expect(request?.url.toString()).toEqual(
+        'http://httpbin.org/get?userId=123'
+      )
     })
 
     it('should access request method', () => {

--- a/test/intercept/http/http.get.test.ts
+++ b/test/intercept/http/http.get.test.ts
@@ -50,7 +50,7 @@ describe('http.get', () => {
     })
 
     it('should access request query parameters', () => {
-      expect(request?.query.get('userId')).toEqual('123')
+      expect(request?.url.searchParams.get('userId')).toEqual('123')
     })
 
     it('should access custom request headers', () => {

--- a/test/intercept/http/http.request.test.ts
+++ b/test/intercept/http/http.request.test.ts
@@ -51,7 +51,7 @@ describe('http.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -94,7 +94,7 @@ describe('http.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access request body', () => {
@@ -141,7 +141,7 @@ describe('http.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access request body', () => {
@@ -184,7 +184,7 @@ describe('http.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -223,7 +223,7 @@ describe('http.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {

--- a/test/intercept/http/http.request.test.ts
+++ b/test/intercept/http/http.request.test.ts
@@ -40,7 +40,10 @@ describe('http.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/get')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/get?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -80,7 +83,10 @@ describe('http.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/post')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/post?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -124,7 +130,10 @@ describe('http.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/put')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/put?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -164,7 +173,10 @@ describe('http.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/delete')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/delete?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -200,7 +212,10 @@ describe('http.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'http://httpbin.org/patch')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'http://httpbin.org/patch?userId=123'
+        )
       })
 
       it('should access request method', () => {

--- a/test/intercept/https/https.get.test.ts
+++ b/test/intercept/https/https.get.test.ts
@@ -50,7 +50,7 @@ describe('https.get', () => {
     })
 
     it('should access request query parameters', () => {
-      expect(request?.query.get('userId')).toEqual('123')
+      expect(request?.url.searchParams.get('userId')).toEqual('123')
     })
 
     it('should access custom request headers', () => {

--- a/test/intercept/https/https.get.test.ts
+++ b/test/intercept/https/https.get.test.ts
@@ -39,7 +39,10 @@ describe('https.get', () => {
     })
 
     it('should access request url', () => {
-      expect(request).toHaveProperty('url', 'https://httpbin.org/get')
+      expect(request?.url).toBeInstanceOf(URL)
+      expect(request?.url.toString()).toEqual(
+        'https://httpbin.org/get?userId=123'
+      )
     })
 
     it('should access request method', () => {

--- a/test/intercept/https/https.request.test.ts
+++ b/test/intercept/https/https.request.test.ts
@@ -51,7 +51,7 @@ describe('https.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -94,7 +94,7 @@ describe('https.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access request body', () => {
@@ -141,7 +141,7 @@ describe('https.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access request body', () => {
@@ -184,7 +184,7 @@ describe('https.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {
@@ -223,7 +223,7 @@ describe('https.request', () => {
       })
 
       it('should access request query parameters', () => {
-        expect(request?.query.get('userId')).toEqual('123')
+        expect(request?.url.searchParams.get('userId')).toEqual('123')
       })
 
       it('should access custom request headers', () => {

--- a/test/intercept/https/https.request.test.ts
+++ b/test/intercept/https/https.request.test.ts
@@ -40,7 +40,10 @@ describe('https.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/get')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/get?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -80,7 +83,10 @@ describe('https.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/post')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/post?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -124,7 +130,10 @@ describe('https.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/put')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/put?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -164,7 +173,10 @@ describe('https.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/delete')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/delete?userId=123'
+        )
       })
 
       it('should access request method', () => {
@@ -200,7 +212,10 @@ describe('https.request', () => {
       })
 
       it('should access request url', () => {
-        expect(request).toHaveProperty('url', 'https://httpbin.org/patch')
+        expect(request?.url).toBeInstanceOf(URL)
+        expect(request?.url.toString()).toEqual(
+          'https://httpbin.org/patch?userId=123'
+        )
       })
 
       it('should access request method', () => {

--- a/test/response/fetch.test.ts
+++ b/test/response/fetch.test.ts
@@ -11,7 +11,9 @@ describe('fetch', () => {
     interceptor = new RequestInterceptor()
     interceptor.use((req) => {
       if (
-        ['https://api.github.com/', 'http://api.github.com/'].includes(req.url)
+        ['https://api.github.com', 'http://api.github.com'].includes(
+          req.url.origin
+        )
       ) {
         return {
           status: 201,

--- a/test/response/http.test.ts
+++ b/test/response/http.test.ts
@@ -10,7 +10,7 @@ describe('http', () => {
   beforeAll(() => {
     interceptor = new RequestInterceptor()
     interceptor.use((req) => {
-      if (['http://api.github.com/'].includes(req.url)) {
+      if (['http://api.github.com'].includes(req.url.origin)) {
         return {
           status: 301,
           headers: {

--- a/test/response/https.test.ts
+++ b/test/response/https.test.ts
@@ -11,7 +11,7 @@ describe('https', () => {
   beforeAll(() => {
     interceptor = new RequestInterceptor()
     interceptor.use((req) => {
-      if (['https://test.msw.io/'].includes(req.url)) {
+      if (['https://test.msw.io'].includes(req.url.origin)) {
         return {
           status: 301,
           headers: {

--- a/test/response/xhr.test.ts
+++ b/test/response/xhr.test.ts
@@ -34,11 +34,12 @@ describe('XHR', () => {
   beforeAll(() => {
     interceptor = new RequestInterceptor()
     interceptor.use((req) => {
-      if (
-        ['https://test.msw.io/', 'http://test.msw.io/', '/login'].includes(
-          req.url
-        )
-      ) {
+      const shouldMock =
+        ['https://test.msw.io', 'http://test.msw.io'].includes(
+          req.url.origin
+        ) || ['/login'].includes(req.url.pathname)
+
+      if (shouldMock) {
         return {
           status: 301,
           headers: {


### PR DESCRIPTION
## Changes

- Intercepted `req.url` is now an instance of the `URL` class, which allows to get additional information about the URL (such as `protocol` or `searchParams`).
- Removes `req.query` as it can be accessed by `req.url.searchParams`

## GitHub

- Related to https://github.com/mswjs/msw/issues/158

## Roadmap

- [x] Remove `req.query`, as it's a mirror of `req.url.searchParams`