### PR TITLE
Sets build target to "es5" to support export from

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "strict": true,
-    "target": "es6",
+    "target": "ES5",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "typeRoots": ["node_modules/@types"],


### PR DESCRIPTION
- Solves the error message on the consumption's side about the inability to digest `export * from 'a'` syntax