### PR TITLE
XMLHttpRequest: resolves DONE readyState on mocked response

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/jest": "^25.2.1",
     "@types/node": "^13.13.2",
     "@types/node-fetch": "^2.5.7",
+    "axios": "^0.19.2",
     "jest": "^25.4.0",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.2",

--- a/src/RequestInterceptor.ts
+++ b/src/RequestInterceptor.ts
@@ -2,7 +2,7 @@ import { RequestMiddleware, ModuleOverride } from './glossary'
 import { overrideHttpModule } from './http/override'
 import { overrideXhrModule } from './XMLHttpRequest/override'
 
-const debug = require('debug')('root')
+const debug = require('debug')('interceptor')
 
 export class RequestInterceptor {
   private overrides: ReturnType<ModuleOverride>[]

--- a/src/XMLHttpRequest/override.ts
+++ b/src/XMLHttpRequest/override.ts
@@ -1,6 +1,8 @@
 import { ModuleOverride } from '../glossary'
 import { createXMLHttpRequestOverride } from './XMLHttpRequest/XMLHttpRequestOverride'
 
+const debug = require('debug')('XHR')
+
 const original = {
   XMLHttpRequest:
     // Although executed in node, certain processes emulate the DOM-like environment
@@ -10,6 +12,8 @@ const original = {
 
 export const overrideXhrModule: ModuleOverride = (middleware) => {
   if (original.XMLHttpRequest) {
+    debug('patching "XMLHttpRequest" module')
+
     const XMLHttpRequestOverride = createXMLHttpRequestOverride(
       middleware,
       original.XMLHttpRequest
@@ -21,6 +25,8 @@ export const overrideXhrModule: ModuleOverride = (middleware) => {
 
   return () => {
     if (original.XMLHttpRequest) {
+      debug('reverting patches...')
+
       window.XMLHttpRequest = original.XMLHttpRequest
     }
   }

--- a/test/response/axios.test.ts
+++ b/test/response/axios.test.ts
@@ -7,8 +7,6 @@ describe('axios', () => {
   beforeAll(() => {
     interceptor = new RequestInterceptor()
     interceptor.use((req) => {
-      console.log('Intercepted:', req)
-
       if (req.url.pathname === '/user') {
         return {
           status: 200,
@@ -33,6 +31,26 @@ describe('axios', () => {
 
     beforeAll(async () => {
       res = await axios.get('/user')
+    })
+
+    it('should return mocked status code', () => {
+      expect(res.status).toEqual(200)
+    })
+
+    it('should return mocked headers', () => {
+      expect(res.headers).toHaveProperty('x-header', 'yes')
+    })
+
+    it('should return mocked body', () => {
+      expect(res.data).toEqual({ mocked: true })
+    })
+  })
+
+  describe('given I perform an axios.post request', () => {
+    let res: AxiosResponse
+
+    beforeAll(async () => {
+      res = await axios.post('/user')
     })
 
     it('should return mocked status code', () => {

--- a/test/response/axios.test.ts
+++ b/test/response/axios.test.ts
@@ -1,0 +1,50 @@
+import axios, { AxiosResponse } from 'axios'
+import { RequestInterceptor } from '../../src'
+
+describe('axios', () => {
+  let interceptor: RequestInterceptor
+
+  beforeAll(() => {
+    interceptor = new RequestInterceptor()
+    interceptor.use((req) => {
+      console.log('Intercepted:', req)
+
+      if (req.url.pathname === '/user') {
+        return {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'x-header': 'yes',
+          },
+          body: JSON.stringify({
+            mocked: true,
+          }),
+        }
+      }
+    })
+  })
+
+  afterAll(() => {
+    interceptor.restore()
+  })
+
+  describe('given I perform an axios.get request', () => {
+    let res: AxiosResponse
+
+    beforeAll(async () => {
+      res = await axios.get('/user')
+    })
+
+    it('should return mocked status code', () => {
+      expect(res.status).toEqual(200)
+    })
+
+    it('should return mocked headers', () => {
+      expect(res.headers).toHaveProperty('x-header', 'yes')
+    })
+
+    it('should return mocked body', () => {
+      expect(res.data).toEqual({ mocked: true })
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,6 +710,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 babel-jest@^25.4.0:
   version "25.4.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.4.0.tgz#409eb3e2ddc2ad9a92afdbb00991f1633f8018d0"
@@ -1059,6 +1066,13 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1350,6 +1364,13 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Changes

- XHR now explicitly sets `readyState` to DONE when a mocked response is set. This resolves the request promise in libraries like `axios`.
- XHR now triggers a `progress` event when a mocked response is set. Takes into account the length of a mocked response body.
- XHR now sets `readyState` to `HEADERS_RECEIVED` when the mocked headers are set.
- Minor adjustments to XHR-related modules

## Tests

- Adds a unit test for a mocked response to `axios.get`/`axios.post`

## GitHub

- Fixes #13 