### PR TITLE
Socket: Adds "setNoDelay", "setKeepAlive" and "setTimeout" methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "scripts": {
     "start": "tsc --build -w",
-    "test": "jest",
+    "test": "jest --no-cache --runInBand",
     "clean": "rimraf lib",
     "build": "yarn clean && tsc --build",
     "prepublishOnly": "yarn test && yarn build"

--- a/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
@@ -287,6 +287,13 @@ export const createXMLHttpRequestOverride = (
             this.responseText = originalRequest.responseText
             this.responseXML = originalRequest.responseXML
 
+            debug(
+              'received original response status:',
+              this.status,
+              this.statusText
+            )
+            debug('received original response body:', this.response)
+
             this.trigger('loadstart')
             this.trigger('load')
           }

--- a/src/http/ClientRequest/ClientRequestOverride.ts
+++ b/src/http/ClientRequest/ClientRequestOverride.ts
@@ -25,6 +25,8 @@ export function createClientRequestOverrideClass(
     this: ClientRequest,
     ...args: Parameters<typeof http['request']>
   ) {
+    debug('created with arguments', args)
+
     const [url, options, callback] = normalizeHttpRequestParams(...args)
     const usesHttps = url.protocol === 'https:'
     const requestBodyBuffer: any[] = []

--- a/src/http/ClientRequest/Socket.ts
+++ b/src/http/ClientRequest/Socket.ts
@@ -73,6 +73,35 @@ export class Socket extends EventEmitter {
     }
   }
 
+  /**
+   * Enable/disable the use of Nagle's algorithm.
+   * Nagle's algorithm delays data before it is sent via the network.
+   */
+  setNoDelay(noDelay: boolean = true): Socket {
+    if (noDelay) {
+      this.totalDelayMs = 0
+    }
+
+    return this
+  }
+
+  /**
+   * Enable/disable keep-alive functionality, and optionally set the initial delay before
+   * the first keepalive probe is sent on an idle socket.
+   */
+  setKeepAlive(): Socket {
+    return this
+  }
+
+  setTimeout(timeout: number, callback?: () => void): Socket {
+    setTimeout(() => {
+      callback?.()
+      this.emit('timeout')
+    }, timeout)
+
+    return this
+  }
+
   getPeerCertificate() {
     return Buffer.from(
       (Math.random() * 10000 + Date.now()).toString()
@@ -80,6 +109,7 @@ export class Socket extends EventEmitter {
   }
 
   // Mock methods required to write to the response body.
+  pause() {}
   resume() {}
   cork() {}
   uncork() {}

--- a/src/http/ClientRequest/Socket.ts
+++ b/src/http/ClientRequest/Socket.ts
@@ -109,8 +109,14 @@ export class Socket extends EventEmitter {
   }
 
   // Mock methods required to write to the response body.
-  pause() {}
-  resume() {}
+  pause(): Socket {
+    return this
+  }
+
+  resume(): Socket {
+    return this
+  }
+
   cork() {}
   uncork() {}
 

--- a/src/http/ClientRequest/normalizeHttpRequestParams.test.ts
+++ b/src/http/ClientRequest/normalizeHttpRequestParams.test.ts
@@ -1,0 +1,148 @@
+import { normalizeHttpRequestParams } from './normalizeHttpRequestParams'
+
+test('handles [string, callback] input', () => {
+  const [
+    url,
+    options,
+    callback,
+  ] = normalizeHttpRequestParams('https://mswjs.io/resource', function cb() {})
+
+  // URL string must be converted to a URL instance
+  expect(url.toJSON()).toEqual(new URL('https://mswjs.io/resource').toJSON())
+
+  // Request options must be derived from the URL instance
+  expect(options).toHaveProperty('method', 'GET')
+  expect(options).toHaveProperty('protocol', 'https:')
+  expect(options).toHaveProperty('hostname', 'mswjs.io')
+  expect(options).toHaveProperty('path', '/resource')
+
+  // Callback must be preserved
+  expect(callback).toHaveProperty('name', 'cb')
+})
+
+test('handles [string, RequestOptions, callback] input', () => {
+  const initialOptions = {
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  }
+  const [
+    url,
+    options,
+    callback,
+  ] = normalizeHttpRequestParams(
+    'https://mswjs.io/resource',
+    initialOptions,
+    function cb() {}
+  )
+
+  // URL must be created from the string
+  expect(url.toJSON()).toEqual(new URL('https://mswjs.io/resource').toJSON())
+
+  // Request options must be preserved
+  expect(options).toEqual(initialOptions)
+
+  // Callback must be preserved
+  expect(callback).toHaveProperty('name', 'cb')
+})
+
+test('handles [URL, callback] input', () => {
+  const [url, options, callback] = normalizeHttpRequestParams(
+    new URL('https://mswjs.io/resource'),
+    function cb() {}
+  )
+
+  // URL must be preserved
+  expect(url.toJSON()).toEqual(new URL('https://mswjs.io/resource').toJSON())
+
+  // Request options must be derived from the URL instance
+  expect(options).toHaveProperty('method', 'GET')
+  expect(options).toHaveProperty('protocol', 'https:')
+  expect(options).toHaveProperty('hostname', 'mswjs.io')
+  expect(options).toHaveProperty('path', '/resource')
+
+  // Callback must be preserved
+  expect(callback).toHaveProperty('name', 'cb')
+})
+
+test('handles [URL, RequestOptions, callback] input', () => {
+  const [url, options, callback] = normalizeHttpRequestParams(
+    new URL('https://mswjs.io/resource'),
+    {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    },
+    function cb() {}
+  )
+
+  // URL must be preserved
+  expect(url.toJSON()).toEqual(new URL('https://mswjs.io/resource').toJSON())
+
+  // Options must be preserved
+  expect(options).toEqual({
+    protocol: 'https:',
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  })
+
+  // Callback must be preserved
+  expect(callback).toHaveProperty('name', 'cb')
+})
+
+test('handles [RequestOptions, callback] input', () => {
+  const initialOptions = {
+    method: 'POST',
+    protocol: 'https:',
+    host: 'mswjs.io',
+    path: '/resource',
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  }
+  const [url, options, callback] = normalizeHttpRequestParams(
+    initialOptions,
+    function cb() {}
+  )
+
+  // URL must be derived from request options
+  expect(url.toJSON()).toEqual(new URL('https://mswjs.io/resource').toJSON())
+
+  // Request options must be preserved
+  expect(options).toEqual(initialOptions)
+
+  // Callback must be preserved
+  expect(callback).toHaveProperty('name', 'cb')
+})
+
+/**
+ * @see https://github.com/mswjs/node-request-interceptor/issues/19
+ */
+test('handles [PartialRequestOptions, callback] input', () => {
+  const initialOptions = {
+    method: 'GET',
+    port: '50176',
+    path: '/resource',
+    host: '127.0.0.1',
+    ca: undefined,
+    key: undefined,
+    pfx: undefined,
+    cert: undefined,
+    passphrase: undefined,
+    agent: false,
+  }
+  const [url, options, callback] = normalizeHttpRequestParams(
+    initialOptions,
+    function cb() {}
+  )
+
+  // URL must be derived from request options
+  expect(url.toJSON()).toEqual(new URL('http://127.0.0.1/resource').toJSON())
+
+  // Request options must be preserved
+  expect(options).toEqual(initialOptions)
+
+  // Callback must be preserved
+  expect(callback).toHaveProperty('name', 'cb')
+})

--- a/src/http/ClientRequest/normalizeHttpRequestParams.ts
+++ b/src/http/ClientRequest/normalizeHttpRequestParams.ts
@@ -1,6 +1,6 @@
 import { RequestOptions } from 'https'
 import { HttpRequestCallback } from '../../glossary'
-import { urlToOptions } from '../../utils/urlToOptions'
+import { getRequestOptionsByUrl } from '../../utils/getRequestOptionsByUrl'
 
 const debug = require('debug')('http:normalize-http-request-params')
 
@@ -26,7 +26,7 @@ function resolveRequestOptions(
   // Calling `fetch` provides only URL to ClientRequest,
   // without RequestOptions or callback.
   if (['function', 'undefined'].includes(typeof args[1])) {
-    return urlToOptions(url)
+    return getRequestOptionsByUrl(url)
   }
 
   return args[1] as RequestOptions

--- a/src/utils/getRequestOptionsByUrl.ts
+++ b/src/utils/getRequestOptionsByUrl.ts
@@ -1,11 +1,11 @@
 import { RequestOptions } from 'http'
 
 /**
- * Converts a URL instance into an ordinary object expected by
- * the `http.request`/`https.request` calls.
+ * Converts a URL instance into the RequestOptions object expected by
+ * the `ClientRequest` class.
  * @see https://github.com/nodejs/node/blob/908292cf1f551c614a733d858528ffb13fb3a524/lib/internal/url.js#L1257
  */
-export function urlToOptions(url: URL): RequestOptions {
+export function getRequestOptionsByUrl(url: URL): RequestOptions {
   const options: RequestOptions = {
     method: 'GET',
     protocol: url.protocol,

--- a/src/utils/urlToOptions.ts
+++ b/src/utils/urlToOptions.ts
@@ -3,31 +3,25 @@ import { RequestOptions } from 'http'
 /**
  * Converts a URL instance into an ordinary object expected by
  * the `http.request`/`https.request` calls.
- *
  * @see https://github.com/nodejs/node/blob/908292cf1f551c614a733d858528ffb13fb3a524/lib/internal/url.js#L1257
  */
 export function urlToOptions(url: URL): RequestOptions {
-  const options = {
+  const options: RequestOptions = {
+    method: 'GET',
     protocol: url.protocol,
     hostname:
       typeof url.hostname === 'string' && url.hostname.startsWith('[')
         ? url.hostname.slice(1, -1)
         : url.hostname,
-    hash: url.hash,
-    search: url.search,
-    pathname: url.pathname,
+    host: url.host,
     path: `${url.pathname}${url.search || ''}`,
-    href: url.href,
-    method: 'GET',
   }
 
-  if (url.port !== '') {
-    // @ts-ignore
+  if (!!url.port) {
     options.port = Number(url.port)
   }
 
   if (url.username || url.password) {
-    // @ts-ignore
     options.auth = `${url.username}:${url.password}`
   }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,12 +1,13 @@
 import https from 'https'
 import http, { IncomingMessage, RequestOptions } from 'http'
 import nodeFetch, { Response, RequestInfo, RequestInit } from 'node-fetch'
-import { urlToOptions } from '../src/utils/urlToOptions'
+import { getRequestOptionsByUrl } from '../src/utils/getRequestOptionsByUrl'
 import { InterceptedRequest } from '../src/glossary'
 import { getCleanUrl } from '../src/utils/getCleanUrl'
 
 interface PromisifiedResponse {
   res: IncomingMessage
+  resBody: string
   url: string
   options: RequestOptions
 }
@@ -15,15 +16,22 @@ export function httpGet(
   url: string,
   options?: RequestOptions
 ): Promise<PromisifiedResponse> {
+  let resBody = ''
   const parsedUrl = new URL(url)
-  const resolvedOptions = Object.assign({}, urlToOptions(parsedUrl), options)
+  const resolvedOptions = Object.assign(
+    {},
+    getRequestOptionsByUrl(parsedUrl),
+    options
+  )
 
   return new Promise((resolve, reject) => {
     http.get(resolvedOptions, (res) => {
       res.setEncoding('utf8')
-      res.on('data', () => null)
+      res.on('data', (chunk) => (resBody += chunk))
       res.on('error', reject)
-      res.on('end', () => resolve({ res, url, options: resolvedOptions }))
+      res.on('end', () =>
+        resolve({ res, resBody, url, options: resolvedOptions })
+      )
     })
   })
 }
@@ -32,15 +40,22 @@ export function httpsGet(
   url: string,
   options?: RequestOptions
 ): Promise<PromisifiedResponse> {
+  let resBody = ''
   const parsedUrl = new URL(url)
-  const resolvedOptions = Object.assign({}, urlToOptions(parsedUrl), options)
+  const resolvedOptions = Object.assign(
+    {},
+    getRequestOptionsByUrl(parsedUrl),
+    options
+  )
 
   return new Promise((resolve, reject) => {
     https.get(resolvedOptions, (res) => {
       res.setEncoding('utf8')
-      res.on('data', () => null)
+      res.on('data', (chunk) => (resBody += chunk))
       res.on('error', reject)
-      res.on('end', () => resolve({ res, url, options: resolvedOptions }))
+      res.on('end', () =>
+        resolve({ res, resBody, url, options: resolvedOptions })
+      )
     })
   })
 }
@@ -50,15 +65,22 @@ export function httpRequest(
   options?: RequestOptions,
   body?: string
 ): Promise<PromisifiedResponse> {
+  let resBody = ''
   const parsedUrl = new URL(url)
-  const resolvedOptions = Object.assign({}, urlToOptions(parsedUrl), options)
+  const resolvedOptions = Object.assign(
+    {},
+    getRequestOptionsByUrl(parsedUrl),
+    options
+  )
 
   return new Promise((resolve, reject) => {
     const req = http.request(resolvedOptions, (res) => {
       res.setEncoding('utf8')
-      res.on('data', () => null)
+      res.on('data', (chunk) => (resBody += chunk))
       res.on('error', reject)
-      res.on('end', () => resolve({ res, url, options: resolvedOptions }))
+      res.on('end', () =>
+        resolve({ res, resBody, url, options: resolvedOptions })
+      )
     })
 
     if (body) {
@@ -74,15 +96,22 @@ export function httpsRequest(
   options?: RequestOptions,
   body?: string
 ): Promise<PromisifiedResponse> {
+  let resBody = ''
   const parsedUrl = new URL(url)
-  const resolvedOptions = Object.assign({}, urlToOptions(parsedUrl), options)
+  const resolvedOptions = Object.assign(
+    {},
+    getRequestOptionsByUrl(parsedUrl),
+    options
+  )
 
   return new Promise((resolve, reject) => {
     const req = https.request(resolvedOptions, (res) => {
       res.setEncoding('utf8')
-      res.on('data', () => null)
+      res.on('data', (chunk) => (resBody += chunk))
       res.on('error', reject)
-      res.on('end', () => resolve({ res, url, options: resolvedOptions }))
+      res.on('end', () =>
+        resolve({ res, resBody, url, options: resolvedOptions })
+      )
     })
 
     if (body) {

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
@@ -11,412 +11,210 @@ function prepareXHR(
   })
 }
 
-describe('XMLHttpRequest', () => {
-  let requestInterceptor: RequestInterceptor
-  const pool: InterceptedRequest[] = []
+let requestInterceptor: RequestInterceptor
+let pool: InterceptedRequest[] = []
 
-  beforeAll(() => {
-    requestInterceptor = new RequestInterceptor()
-    requestInterceptor.use((req) => {
-      pool.push(req)
-    })
+beforeAll(() => {
+  requestInterceptor = new RequestInterceptor()
+  requestInterceptor.use((req) => {
+    pool.push(req)
   })
-
-  afterAll(() => {
-    requestInterceptor.restore()
-  })
-
-  describe('given I perform an HTTP XMLHttpRequest', () => {
-    describe('GET', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('GET', 'http://httpbin.org/get?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/get?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'GET')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('POST', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('POST', 'http://httpbin.org/post?userId=123', {
-            body: 'request-body',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/post?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'POST')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access request body', () => {
-        expect(request).toHaveProperty('body', 'request-body')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('PUT', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('PUT', 'http://httpbin.org/put?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/put?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'PUT')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('DELETE', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('DELETE', 'http://httpbin.org/delete?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/delete?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'DELETE')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('PATCH', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('PATCH', 'http://httpbin.org/patch?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/patch?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'PATCH')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-  })
-
-  describe('given I perform an HTTPS XMLHttpRequest', () => {
-    describe('GET', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('GET', 'https://httpbin.org/get?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/get?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'GET')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('POST', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('POST', 'https://httpbin.org/post?userId=123', {
-            body: 'request-body',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/post?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'POST')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access request body', () => {
-        expect(request).toHaveProperty('body', 'request-body')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('PUT', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('PUT', 'https://httpbin.org/put?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/put?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'PUT')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('DELETE', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('DELETE', 'https://httpbin.org/delete?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/delete?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'DELETE')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('PATCH', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareXHR(
-          xhr('PATCH', 'https://httpbin.org/patch?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/patch?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'PATCH')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-  })
+})
+
+afterEach(() => {
+  pool = []
+})
+
+afterAll(() => {
+  requestInterceptor.restore()
+})
+
+test('intercepts an HTTP GET request', async () => {
+  const request = await prepareXHR(
+    xhr('GET', 'http://httpbin.org/get?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/get?userId=123')
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTP POST request', async () => {
+  const request = await prepareXHR(
+    xhr('POST', 'http://httpbin.org/post?userId=123', {
+      body: 'request-body',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/post?userId=123')
+  expect(request).toHaveProperty('method', 'POST')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request).toHaveProperty('body', 'request-body')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTP PUT request', async () => {
+  const request = await prepareXHR(
+    xhr('PUT', 'http://httpbin.org/put?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/put?userId=123')
+  expect(request).toHaveProperty('method', 'PUT')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTP DELETE request', async () => {
+  const request = await prepareXHR(
+    xhr('DELETE', 'http://httpbin.org/delete?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual(
+    'http://httpbin.org/delete?userId=123'
+  )
+  expect(request).toHaveProperty('method', 'DELETE')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTP PATCH request', async () => {
+  const request = await prepareXHR(
+    xhr('PATCH', 'http://httpbin.org/patch?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/patch?userId=123')
+  expect(request).toHaveProperty('method', 'PATCH')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTP GET request', async () => {
+  const request = await prepareXHR(
+    xhr('GET', 'https://httpbin.org/get?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('https://httpbin.org/get?userId=123')
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTPS POST request', async () => {
+  const request = await prepareXHR(
+    xhr('POST', 'https://httpbin.org/post?userId=123', {
+      body: 'request-body',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('https://httpbin.org/post?userId=123')
+  expect(request).toHaveProperty('method', 'POST')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request).toHaveProperty('body', 'request-body')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTPS PUT request', async () => {
+  const request = await prepareXHR(
+    xhr('PUT', 'https://httpbin.org/put?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('https://httpbin.org/put?userId=123')
+  expect(request).toHaveProperty('method', 'PUT')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTPS DELETE request', async () => {
+  const request = await prepareXHR(
+    xhr('DELETE', 'https://httpbin.org/delete?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual(
+    'https://httpbin.org/delete?userId=123'
+  )
+  expect(request).toHaveProperty('method', 'DELETE')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an HTTP PATCH request', async () => {
+  const request = await prepareXHR(
+    xhr('PATCH', 'https://httpbin.org/patch?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual(
+    'https://httpbin.org/patch?userId=123'
+  )
+  expect(request).toHaveProperty('method', 'PATCH')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
 })

--- a/test/intercept/fetch/fetch.test.ts
+++ b/test/intercept/fetch/fetch.test.ts
@@ -14,377 +14,186 @@ async function prepareFetch(
   })
 }
 
-describe('fetch', () => {
-  let requestInterceptor: RequestInterceptor
-  const pool: InterceptedRequest[] = []
+let requestInterceptor: RequestInterceptor
+let pool: InterceptedRequest[] = []
 
-  beforeAll(() => {
-    requestInterceptor = new RequestInterceptor()
-    requestInterceptor.use((req) => {
-      pool.push(req)
-    })
+beforeAll(() => {
+  requestInterceptor = new RequestInterceptor()
+  requestInterceptor.use((req) => {
+    pool.push(req)
   })
-
-  afterAll(() => {
-    requestInterceptor.restore()
-  })
-
-  describe('given I perform an HTTP fetch request', () => {
-    describe('GET', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareFetch(
-          fetch('http://httpbin.org/get?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/get?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'GET')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access default request headers', () => {
-        expect(request?.headers).toHaveProperty('accept', ['*/*'])
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
-      })
-    })
-
-    describe('POST', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareFetch(
-          fetch('http://httpbin.org/post?userId=123', {
-            method: 'POST',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-            body: JSON.stringify({ body: true }),
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/post?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'POST')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access request body', () => {
-        expect(request).toHaveProperty('body', JSON.stringify({ body: true }))
-      })
-
-      it('should access default request headers', () => {
-        expect(request?.headers).toHaveProperty('accept', ['*/*'])
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
-      })
-    })
-
-    describe('PUT', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareFetch(
-          fetch('http://httpbin.org/put?userId=123', {
-            method: 'PUT',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/put?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'PUT')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access default request headers', () => {
-        expect(request?.headers).toHaveProperty('accept', ['*/*'])
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
-      })
-    })
-
-    describe('DELETE', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareFetch(
-          fetch('http://httpbin.org/delete?userId=123', {
-            method: 'DELETE',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/delete?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'DELETE')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access default request headers', () => {
-        expect(request?.headers).toHaveProperty('accept', ['*/*'])
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
-      })
-    })
-  })
-
-  /**
-   * HTTPS
-   */
-  describe('given I perform an HTTPS fetch request', () => {
-    describe('GET', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareFetch(
-          fetch('https://httpbin.org/get?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/get?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'GET')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access default request headers', () => {
-        expect(request?.headers).toHaveProperty('accept', ['*/*'])
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
-      })
-    })
-
-    describe('POST', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareFetch(
-          fetch('https://httpbin.org/post?userId=123', {
-            method: 'POST',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-            body: JSON.stringify({ body: true }),
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/post?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'POST')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access request body', () => {
-        expect(request).toHaveProperty('body', JSON.stringify({ body: true }))
-      })
-
-      it('should access default request headers', () => {
-        expect(request?.headers).toHaveProperty('accept', ['*/*'])
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
-      })
-    })
-
-    describe('PUT', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareFetch(
-          fetch('https://httpbin.org/put?userId=123', {
-            method: 'PUT',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/put?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'PUT')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access default request headers', () => {
-        expect(request?.headers).toHaveProperty('accept', ['*/*'])
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
-      })
-    })
-
-    describe('DELETE', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepareFetch(
-          fetch('https://httpbin.org/delete?userId=123', {
-            method: 'DELETE',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'https://httpbin.org/delete?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'DELETE')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access default request headers', () => {
-        expect(request?.headers).toHaveProperty('accept', ['*/*'])
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
-      })
-    })
-  })
+})
+
+afterEach(() => {
+  pool = []
+})
+
+afterAll(() => {
+  requestInterceptor.restore()
+})
+
+test('intercepts an HTTP GET request', async () => {
+  const request = await prepareFetch(
+    fetch('http://httpbin.org/get?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/get?userId=123')
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('accept', ['*/*'])
+  expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
+})
+
+test('intercepts an HTTP POST request', async () => {
+  const request = await prepareFetch(
+    fetch('http://httpbin.org/post?userId=123', {
+      method: 'POST',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+      body: JSON.stringify({ body: true }),
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/post?userId=123')
+  expect(request).toHaveProperty('method', 'POST')
+  expect(request?.headers).toHaveProperty('accept', ['*/*'])
+  expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request).toHaveProperty('body', JSON.stringify({ body: true }))
+})
+
+test('intercepts an HTTP PUT request', async () => {
+  const request = await prepareFetch(
+    fetch('http://httpbin.org/put?userId=123', {
+      method: 'PUT',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/put?userId=123')
+  expect(request).toHaveProperty('method', 'PUT')
+  expect(request?.headers).toHaveProperty('accept', ['*/*'])
+  expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+})
+
+test('intercepts an HTTP DELETE request', async () => {
+  const request = await prepareFetch(
+    fetch('http://httpbin.org/delete?userId=123', {
+      method: 'DELETE',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual(
+    'http://httpbin.org/delete?userId=123'
+  )
+  expect(request).toHaveProperty('method', 'DELETE')
+  expect(request?.headers).toHaveProperty('accept', ['*/*'])
+  expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+})
+
+test('intercepts an HTTPS GET request', async () => {
+  const request = await prepareFetch(
+    fetch('https://httpbin.org/get?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('https://httpbin.org/get?userId=123')
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request?.headers).toHaveProperty('accept', ['*/*'])
+  expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+})
+
+test('intercepts an HTTPS POST request', async () => {
+  const request = await prepareFetch(
+    fetch('https://httpbin.org/post?userId=123', {
+      method: 'POST',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+      body: JSON.stringify({ body: true }),
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('https://httpbin.org/post?userId=123')
+  expect(request).toHaveProperty('method', 'POST')
+  expect(request?.headers).toHaveProperty('accept', ['*/*'])
+  expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request).toHaveProperty('body', JSON.stringify({ body: true }))
+})
+
+test('intercepts an HTTPS PUT request', async () => {
+  const request = await prepareFetch(
+    fetch('https://httpbin.org/put?userId=123', {
+      method: 'PUT',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('https://httpbin.org/put?userId=123')
+  expect(request).toHaveProperty('method', 'PUT')
+  expect(request?.headers).toHaveProperty('accept', ['*/*'])
+  expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+})
+
+test('intercepts an HTTPS DELETE request', async () => {
+  const request = await prepareFetch(
+    fetch('https://httpbin.org/delete?userId=123', {
+      method: 'DELETE',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
+
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual(
+    'https://httpbin.org/delete?userId=123'
+  )
+  expect(request).toHaveProperty('method', 'DELETE')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('accept', ['*/*'])
+  expect(request?.headers).toHaveProperty('x-custom-header', ['yes'])
 })

--- a/test/intercept/http/http.get.test.ts
+++ b/test/intercept/http/http.get.test.ts
@@ -5,56 +5,38 @@ import { RequestInterceptor } from '../../../src'
 import { InterceptedRequest } from '../../../src/glossary'
 import { httpGet, prepare } from '../../helpers'
 
-describe('http.get', () => {
-  let requestInterceptor: RequestInterceptor
-  const pool: InterceptedRequest[] = []
+let requestInterceptor: RequestInterceptor
+let pool: InterceptedRequest[] = []
 
-  beforeAll(() => {
-    requestInterceptor = new RequestInterceptor()
-    requestInterceptor.use((req) => {
-      pool.push(req)
-    })
+beforeAll(() => {
+  requestInterceptor = new RequestInterceptor()
+  requestInterceptor.use((req) => {
+    pool.push(req)
   })
+})
 
-  afterAll(() => {
-    requestInterceptor.restore()
-  })
+afterEach(() => {
+  pool = []
+})
 
-  describe('given I perform a request using http.get', () => {
-    let request: InterceptedRequest | undefined
+afterAll(() => {
+  requestInterceptor.restore()
+})
 
-    beforeAll(async () => {
-      request = await prepare(
-        httpGet('http://httpbin.org/get?userId=123', {
-          headers: {
-            'x-custom-header': 'yes',
-          },
-        }),
-        pool
-      )
-    })
+test('intercepts an http.get request', async () => {
+  const request = await prepare(
+    httpGet('http://httpbin.org/get?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
 
-    it('should intercept the request', () => {
-      expect(request).toBeTruthy()
-    })
-
-    it('should access request url', () => {
-      expect(request?.url).toBeInstanceOf(URL)
-      expect(request?.url.toString()).toEqual(
-        'http://httpbin.org/get?userId=123'
-      )
-    })
-
-    it('should access request method', () => {
-      expect(request).toHaveProperty('method', 'GET')
-    })
-
-    it('should access request query parameters', () => {
-      expect(request?.url.searchParams.get('userId')).toEqual('123')
-    })
-
-    it('should access custom request headers', () => {
-      expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-    })
-  })
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/get?userId=123')
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
 })

--- a/test/intercept/http/http.request.test.ts
+++ b/test/intercept/http/http.request.test.ts
@@ -5,230 +5,126 @@ import { RequestInterceptor } from '../../../src'
 import { InterceptedRequest } from '../../../src/glossary'
 import { httpRequest, prepare } from '../../helpers'
 
-describe('http.request', () => {
-  let requestInterceptor: RequestInterceptor
-  const pool: InterceptedRequest[] = []
+let requestInterceptor: RequestInterceptor
+let pool: InterceptedRequest[] = []
 
-  beforeAll(() => {
-    requestInterceptor = new RequestInterceptor()
-    requestInterceptor.use((req) => {
-      pool.push(req)
-    })
+beforeAll(() => {
+  requestInterceptor = new RequestInterceptor()
+  requestInterceptor.use((req) => {
+    pool.push(req)
   })
+})
 
-  afterAll(() => {
-    requestInterceptor.restore()
-  })
+afterEach(() => {
+  pool = []
+})
 
-  describe('given I perform a request using http.request', () => {
-    describe('GET', () => {
-      let request: InterceptedRequest | undefined
+afterAll(() => {
+  requestInterceptor.restore()
+})
 
-      beforeAll(async () => {
-        request = await prepare(
-          httpRequest('http://httpbin.org/get?userId=123', {
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
+test('intercepts HTTP GET request', async () => {
+  const request = await prepare(
+    httpRequest('http://httpbin.org/get?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
 
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/get?userId=123')
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
 
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/get?userId=123'
-        )
-      })
+test('intercepts an HTTP POST request', async () => {
+  const request = await prepare(
+    httpRequest(
+      'http://httpbin.org/post?userId=123',
+      {
+        method: 'POST',
+        headers: {
+          'x-custom-header': 'yes',
+        },
+      },
+      'request-body'
+    ),
+    pool
+  )
 
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'GET')
-      })
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/post?userId=123')
+  expect(request).toHaveProperty('method', 'POST')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request).toHaveProperty('body', 'request-body')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
 
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
+test('intercepts an HTTP PUT request', async () => {
+  const request = await prepare(
+    httpRequest(
+      'http://httpbin.org/put?userId=123',
+      {
+        method: 'PUT',
+        headers: {
+          'x-custom-header': 'yes',
+        },
+      },
+      'request-body'
+    ),
+    pool
+  )
 
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/put?userId=123')
+  expect(request).toHaveProperty('method', 'PUT')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request).toHaveProperty('body', 'request-body')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
 
-    describe('POST', () => {
-      let request: InterceptedRequest | undefined
+test('intercepts an HTTP DELETE request', async () => {
+  const request = await prepare(
+    httpRequest('http://httpbin.org/delete?userId=123', {
+      method: 'DELETE',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
 
-      beforeAll(async () => {
-        request = await prepare(
-          httpRequest(
-            'http://httpbin.org/post?userId=123',
-            {
-              method: 'POST',
-              headers: {
-                'x-custom-header': 'yes',
-              },
-            },
-            'request-body'
-          ),
-          pool
-        )
-      })
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual(
+    'http://httpbin.org/delete?userId=123'
+  )
+  expect(request).toHaveProperty('method', 'DELETE')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
 
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
+test('intercepts an HTTP PATCH request', async () => {
+  const request = await prepare(
+    httpRequest('http://httpbin.org/patch?userId=123', {
+      method: 'PATCH',
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
 
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/post?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'POST')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access request body', () => {
-        expect(request).toHaveProperty('body', 'request-body')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('PUT', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepare(
-          httpRequest(
-            'http://httpbin.org/put?userId=123',
-            {
-              method: 'PUT',
-              headers: {
-                'x-custom-header': 'yes',
-              },
-            },
-            'request-body'
-          ),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/put?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'PUT')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access request body', () => {
-        expect(request).toHaveProperty('body', 'request-body')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('DELETE', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepare(
-          httpRequest('http://httpbin.org/delete?userId=123', {
-            method: 'DELETE',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/delete?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'DELETE')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-
-    describe('PATCH', () => {
-      let request: InterceptedRequest | undefined
-
-      beforeAll(async () => {
-        request = await prepare(
-          httpRequest('http://httpbin.org/patch?userId=123', {
-            method: 'PATCH',
-            headers: {
-              'x-custom-header': 'yes',
-            },
-          }),
-          pool
-        )
-      })
-
-      it('should intercept the request', () => {
-        expect(request).toBeTruthy()
-      })
-
-      it('should access request url', () => {
-        expect(request?.url).toBeInstanceOf(URL)
-        expect(request?.url.toString()).toEqual(
-          'http://httpbin.org/patch?userId=123'
-        )
-      })
-
-      it('should access request method', () => {
-        expect(request).toHaveProperty('method', 'PATCH')
-      })
-
-      it('should access request query parameters', () => {
-        expect(request?.url.searchParams.get('userId')).toEqual('123')
-      })
-
-      it('should access custom request headers', () => {
-        expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-      })
-    })
-  })
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('http://httpbin.org/patch?userId=123')
+  expect(request).toHaveProperty('method', 'PATCH')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
 })

--- a/test/intercept/https/https.get.test.ts
+++ b/test/intercept/https/https.get.test.ts
@@ -5,56 +5,39 @@ import { RequestInterceptor } from '../../../src'
 import { InterceptedRequest } from '../../../src/glossary'
 import { prepare, httpsGet } from '../../helpers'
 
-describe('https.get', () => {
-  let requestInterceptor: RequestInterceptor
-  const pool: InterceptedRequest[] = []
+let requestInterceptor: RequestInterceptor
+let pool: InterceptedRequest[] = []
 
-  beforeAll(() => {
-    requestInterceptor = new RequestInterceptor()
-    requestInterceptor.use((req) => {
-      pool.push(req)
-    })
+beforeAll(() => {
+  requestInterceptor = new RequestInterceptor()
+  requestInterceptor.use((req) => {
+    pool.push(req)
   })
+})
 
-  afterAll(() => {
-    requestInterceptor.restore()
-  })
+afterEach(() => {
+  pool = []
+})
 
-  describe('given I perform a request using http.get', () => {
-    let request: InterceptedRequest | undefined
+afterAll(() => {
+  requestInterceptor.restore()
+})
 
-    beforeAll(async () => {
-      request = await prepare(
-        httpsGet('https://httpbin.org/get?userId=123', {
-          headers: {
-            'x-custom-header': 'yes',
-          },
-        }),
-        pool
-      )
-    })
+test('intercepts an HTTPS GET request', async () => {
+  const request = await prepare(
+    httpsGet('https://httpbin.org/get?userId=123', {
+      headers: {
+        'x-custom-header': 'yes',
+      },
+    }),
+    pool
+  )
 
-    it('should intercept the request', () => {
-      expect(request).toBeTruthy()
-    })
+  expect(request).toBeTruthy()
+  expect(request?.url).toBeInstanceOf(URL)
+  expect(request?.url.toString()).toEqual('https://httpbin.org/get?userId=123')
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request?.url.searchParams.get('userId')).toEqual('123')
 
-    it('should access request url', () => {
-      expect(request?.url).toBeInstanceOf(URL)
-      expect(request?.url.toString()).toEqual(
-        'https://httpbin.org/get?userId=123'
-      )
-    })
-
-    it('should access request method', () => {
-      expect(request).toHaveProperty('method', 'GET')
-    })
-
-    it('should access request query parameters', () => {
-      expect(request?.url.searchParams.get('userId')).toEqual('123')
-    })
-
-    it('should access custom request headers', () => {
-      expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
-    })
-  })
+  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
 })

--- a/test/response/axios.test.ts
+++ b/test/response/axios.test.ts
@@ -1,88 +1,50 @@
 import axios, { AxiosResponse } from 'axios'
 import { RequestInterceptor } from '../../src'
 
-describe('axios', () => {
-  let interceptor: RequestInterceptor
+let interceptor: RequestInterceptor
 
-  beforeAll(() => {
-    interceptor = new RequestInterceptor()
-    interceptor.use((req) => {
-      if (req.url.pathname === '/user') {
-        return {
-          status: 200,
-          headers: {
-            'content-type': 'application/json',
-            'x-header': 'yes',
-          },
-          body: JSON.stringify({
-            mocked: true,
-          }),
-        }
+beforeAll(() => {
+  interceptor = new RequestInterceptor()
+  interceptor.use((req) => {
+    if (req.url.pathname === '/user') {
+      return {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'x-header': 'yes',
+        },
+        body: JSON.stringify({
+          mocked: true,
+        }),
       }
-    })
+    }
   })
+})
 
-  afterAll(() => {
-    interceptor.restore()
-  })
+afterAll(() => {
+  interceptor.restore()
+})
 
-  describe('given I performed a request using "axios"', () => {
-    let res: AxiosResponse
+test('responds with a mocked response to an "axios()" request', async () => {
+  const res = await axios('/user')
 
-    beforeAll(async () => {
-      res = await axios('/user')
-    })
+  expect(res.status).toEqual(200)
+  expect(res.headers).toHaveProperty('x-header', 'yes')
+  expect(res.data).toEqual({ mocked: true })
+})
 
-    it('should return mocked status code', () => {
-      expect(res.status).toEqual(200)
-    })
+test('responds with a mocked response to an "axios.get()" request', async () => {
+  const res = await axios.get('/user')
 
-    it('should return mocked headers', () => {
-      expect(res.headers).toHaveProperty('x-header', 'yes')
-    })
+  expect(res.status).toEqual(200)
+  expect(res.headers).toHaveProperty('x-header', 'yes')
+  expect(res.data).toEqual({ mocked: true })
+})
 
-    it('should return mocked body', () => {
-      expect(res.data).toEqual({ mocked: true })
-    })
-  })
+test('responds with a mocked response to an "axios.post()" request', async () => {
+  const res = await axios.post('/user')
 
-  describe('given I performed a request using "axios.get"', () => {
-    let res: AxiosResponse
-
-    beforeAll(async () => {
-      res = await axios.get('/user')
-    })
-
-    it('should return mocked status code', () => {
-      expect(res.status).toEqual(200)
-    })
-
-    it('should return mocked headers', () => {
-      expect(res.headers).toHaveProperty('x-header', 'yes')
-    })
-
-    it('should return mocked body', () => {
-      expect(res.data).toEqual({ mocked: true })
-    })
-  })
-
-  describe('given I performed a request using "axios.post"', () => {
-    let res: AxiosResponse
-
-    beforeAll(async () => {
-      res = await axios.post('/user')
-    })
-
-    it('should return mocked status code', () => {
-      expect(res.status).toEqual(200)
-    })
-
-    it('should return mocked headers', () => {
-      expect(res.headers).toHaveProperty('x-header', 'yes')
-    })
-
-    it('should return mocked body', () => {
-      expect(res.data).toEqual({ mocked: true })
-    })
-  })
+  expect(res.status).toEqual(200)
+  expect(res.headers).toHaveProperty('x-header', 'yes')
+  expect(res.data).toEqual({ mocked: true })
 })

--- a/test/response/http.test.ts
+++ b/test/response/http.test.ts
@@ -1,156 +1,63 @@
 /**
  * @jest-environment node
  */
-import http, { IncomingMessage } from 'http'
 import { RequestInterceptor } from '../../src'
+import { httpGet, httpRequest } from '../helpers'
 
-describe('http', () => {
-  let interceptor: RequestInterceptor
+let interceptor: RequestInterceptor
 
-  beforeAll(() => {
-    interceptor = new RequestInterceptor()
-    interceptor.use((req) => {
-      if (['http://api.github.com'].includes(req.url.origin)) {
-        return {
-          status: 301,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ mocked: true }),
-        }
+beforeAll(() => {
+  interceptor = new RequestInterceptor()
+  interceptor.use((req) => {
+    if (['http://httpbin.org/'].includes(req.url.href)) {
+      return {
+        status: 301,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ mocked: true }),
       }
-    })
+    }
   })
+})
 
-  afterAll(() => {
-    interceptor.restore()
-  })
+afterAll(() => {
+  interceptor.restore()
+})
 
-  describe('given I set up the interception', () => {
-    describe('and I perform a request using http.request', () => {
-      describe('and that request is handled in the middleware', () => {
-        let res: IncomingMessage
-        let resBody: string = ''
+test('responds to an HTTP request issued by "http.request" and handled in the middleware', async () => {
+  const { res, resBody } = await httpRequest('http://httpbin.org')
 
-        beforeAll((done) => {
-          const req = http.request('http://api.github.com?foo=bar', (res) => {
-            res.setEncoding('utf8')
-            res.on('data', (chunk) => (resBody += chunk))
-            res.on('end', done)
-          })
+  expect(res.statusCode).toBe(301)
+  expect(res.headers).toHaveProperty('content-type', 'application/json')
+  expect(resBody).toEqual(JSON.stringify({ mocked: true }))
+})
 
-          req.on('response', (original) => (res = original))
-          req.end()
-        })
+test('bypasses an HTTP request issued by "http.request" not handled in the middleware', async () => {
+  const { res, resBody } = await httpRequest('http://httpbin.org/get')
 
-        it('should return mocked status code', () => {
-          expect(res.statusCode).toEqual(301)
-        })
+  expect(res.statusCode).toBe(200)
+  expect(resBody).toContain(`\"url\": \"http://httpbin.org/get\"`)
+})
 
-        it('should return mocked headers', () => {
-          expect(res.headers).toHaveProperty('content-type', 'application/json')
-        })
+test('responds to an HTTP request issued by "http.get" and handled in the  middleeware', async () => {
+  const { res, resBody } = await httpRequest('http://httpbin.org')
 
-        it('should return mocked body', () => {
-          expect(resBody).toEqual(JSON.stringify({ mocked: true }))
-        })
-      })
+  expect(res.statusCode).toBe(301)
+  expect(res.headers).toHaveProperty('content-type', 'application/json')
+  expect(resBody).toEqual(JSON.stringify({ mocked: true }))
+})
 
-      describe('and that request is not handled by the middleware', () => {
-        let res: IncomingMessage
-        let resBody: string = ''
+test('bypasses an HTTP request issued by "http.get" not handled in the middleware', async () => {
+  const { res, resBody } = await httpGet('http://httpbin.org/get')
 
-        beforeAll((done) => {
-          const req = http.request('http://httpbin.org/get', (res) => {
-            res.setEncoding('utf8')
-            res.on('data', (chunk) => (resBody += chunk))
-            res.on('end', done)
-          })
+  expect(res.statusCode).toBe(200)
+  expect(resBody).toContain(`\"url\": \"http://httpbin.org/get\"`)
+})
 
-          req.on('response', (original) => (res = original))
-          req.end()
-        })
+test('bypasses any request when the interceptor is restored', async () => {
+  interceptor.restore()
+  const { res } = await httpGet('http://httpbin.org')
 
-        it('should the original response', () => {
-          expect(res.statusCode).toEqual(200)
-          expect(resBody).toContain(`\"url\": \"http://httpbin.org/get\"`)
-        })
-      })
-    })
-
-    describe('and I perform a request using http.get', () => {
-      describe('and that request is handled by the middleware', () => {
-        let res: IncomingMessage
-        let resBody: string = ''
-
-        beforeAll((done) => {
-          const req = http.get('http://api.github.com', (res) => {
-            res.setEncoding('utf8')
-            res.on('data', (chunk) => (resBody += chunk))
-            res.on('end', done)
-          })
-
-          req.on('response', (original) => (res = original))
-          req.end()
-        })
-
-        it('should return mocked status code', () => {
-          expect(res.statusCode).toEqual(301)
-        })
-
-        it('should return mocked headers', () => {
-          expect(res.headers).toHaveProperty('content-type', 'application/json')
-        })
-
-        it('should return mocked body', () => {
-          expect(resBody).toEqual(JSON.stringify({ mocked: true }))
-        })
-      })
-
-      describe('and that request is not handled by the middleware', () => {
-        let res: IncomingMessage
-        let resBody: string = ''
-
-        beforeAll((done) => {
-          const req = http.get('http://httpbin.org/get', (res) => {
-            res.setEncoding('utf8')
-            res.on('data', (chunk) => (resBody += chunk))
-            res.on('end', done)
-          })
-
-          req.on('response', (original) => (res = original))
-          req.end()
-        })
-
-        it('should the original response', () => {
-          expect(res.statusCode).toEqual(200)
-          expect(resBody).toContain(`\"url\": \"http://httpbin.org/get\"`)
-        })
-      })
-    })
-  })
-
-  describe('given I restored the original implementation', () => {
-    beforeAll(() => {
-      interceptor.restore()
-    })
-
-    describe('and I perform an HTTP request', () => {
-      let resBody: string = ''
-
-      beforeAll((done) => {
-        const req = http.get('http://httpbin.org/get', (res) => {
-          res.setEncoding('utf8')
-          res.on('data', (chunk) => (resBody += chunk))
-          res.on('end', done)
-        })
-
-        req.end()
-      })
-
-      it('should return an original response', () => {
-        expect(resBody).toContain(`\"url\": \"http://httpbin.org/get\"`)
-      })
-    })
-  })
+  expect(res.statusCode).toBe(200)
 })

--- a/test/response/https.test.ts
+++ b/test/response/https.test.ts
@@ -1,154 +1,63 @@
 /**
  * @jest-environment node
  */
-import https from 'https'
-import { IncomingMessage } from 'http'
 import { RequestInterceptor } from '../../src'
+import { httpsGet, httpsRequest } from '../helpers'
 
-describe('https', () => {
-  let interceptor: RequestInterceptor
+let interceptor: RequestInterceptor
 
-  beforeAll(() => {
-    interceptor = new RequestInterceptor()
-    interceptor.use((req) => {
-      if (['https://test.msw.io'].includes(req.url.origin)) {
-        return {
-          status: 301,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ mocked: true }),
-        }
+beforeAll(() => {
+  interceptor = new RequestInterceptor()
+  interceptor.use((req) => {
+    if (['https://test.mswjs.io'].includes(req.url.origin)) {
+      return {
+        status: 301,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ mocked: true }),
       }
-    })
+    }
   })
+})
 
-  afterAll(() => {
-    interceptor.restore()
-  })
+afterAll(() => {
+  interceptor.restore()
+})
 
-  describe('given I perform request using https.request', () => {
-    describe('and that request is handled by the middleware', () => {
-      let res: IncomingMessage
-      let resBody: string = ''
+test('responds to an HTTPS request issued by "https.request" and handled in the middleware', async () => {
+  const { res, resBody } = await httpsRequest('https://test.mswjs.io')
 
-      beforeAll((done) => {
-        const req = https.request('https://test.msw.io', (res) => {
-          res.setEncoding('utf8')
-          res.on('data', (chunk) => (resBody += chunk))
-          res.on('end', done)
-        })
+  expect(res.statusCode).toEqual(301)
+  expect(res.headers).toHaveProperty('content-type', 'application/json')
+  expect(resBody).toEqual(JSON.stringify({ mocked: true }))
+})
 
-        req.on('response', (original) => (res = original))
-        req.end()
-      })
+test('bypasses an HTTPS request issued by "https.request" not handled in the middleware', async () => {
+  const { res, resBody } = await httpsRequest('https://httpbin.org/get')
 
-      it('should return mocked status code', () => {
-        expect(res.statusCode).toEqual(301)
-      })
+  expect(res.statusCode).toEqual(200)
+  expect(resBody).toContain(`\"url\": \"https://httpbin.org/get\"`)
+})
 
-      it('should return mocked headers', () => {
-        expect(res.headers).toHaveProperty('content-type', 'application/json')
-      })
+test('responds to an HTTPS request issued by "https.get" and handled in the middleware', async () => {
+  const { res, resBody } = await httpsGet('https://test.mswjs.io')
 
-      it('should return mocked body', () => {
-        expect(resBody).toEqual(JSON.stringify({ mocked: true }))
-      })
-    })
+  expect(res.statusCode).toEqual(301)
+  expect(res.headers).toHaveProperty('content-type', 'application/json')
+  expect(resBody).toEqual(JSON.stringify({ mocked: true }))
+})
 
-    describe('and that request is not handled by the middleware', () => {
-      let res: IncomingMessage
-      let resBody: string = ''
+test('bypasses an HTTPS request issued by "https.get" not handled in the middleware', async () => {
+  const { res, resBody } = await httpsGet('https://httpbin.org/get')
 
-      beforeAll((done) => {
-        const req = https.request('https://httpbin.org/get', (res) => {
-          res.setEncoding('utf8')
-          res.on('data', (chunk) => (resBody += chunk))
-          res.on('end', done)
-        })
+  expect(res.statusCode).toEqual(200)
+  expect(resBody).toContain(`\"url\": \"https://httpbin.org/get\"`)
+})
 
-        req.on('response', (original) => (res = original))
-        req.end()
-      })
+test('bypasses any request when the interceptor is restored', async () => {
+  interceptor.restore()
+  const { res } = await httpsGet('https://test.mswjs.io')
 
-      it('should return mocked status code', () => {
-        expect(res.statusCode).toEqual(200)
-        expect(resBody).toContain(`\"url\": \"https://httpbin.org/get\"`)
-      })
-    })
-  })
-
-  describe('given I perform request using https.get', () => {
-    describe('and that request is handled by the middleware', () => {
-      let res: IncomingMessage
-      let resBody: string = ''
-
-      beforeAll((done) => {
-        const req = https.get('https://test.msw.io', (res) => {
-          res.setEncoding('utf8')
-          res.on('data', (chunk) => (resBody += chunk))
-          res.on('end', done)
-        })
-
-        req.on('response', (original) => (res = original))
-        req.end()
-      })
-
-      it('should return mocked status code', () => {
-        expect(res.statusCode).toEqual(301)
-      })
-
-      it('should return mocked headers', () => {
-        expect(res.headers).toHaveProperty('content-type', 'application/json')
-      })
-
-      it('should return mocked body', () => {
-        expect(resBody).toEqual(JSON.stringify({ mocked: true }))
-      })
-    })
-
-    describe('and that request is not handled by the middleware', () => {
-      let res: IncomingMessage
-      let resBody: string = ''
-
-      beforeAll((done) => {
-        const req = https.get('https://httpbin.org/get', (res) => {
-          res.setEncoding('utf8')
-          res.on('data', (chunk) => (resBody += chunk))
-          res.on('end', done)
-        })
-
-        req.on('response', (original) => (res = original))
-        req.end()
-      })
-
-      it('should return mocked status code', () => {
-        expect(res.statusCode).toEqual(200)
-        expect(resBody).toContain(`\"url\": \"https://httpbin.org/get\"`)
-      })
-    })
-  })
-
-  describe('given I restored the original implementation', () => {
-    beforeAll(() => {
-      interceptor.restore()
-    })
-
-    describe('and I perform an HTTPS request', () => {
-      let resBody: string = ''
-
-      beforeAll((done) => {
-        const req = https.get('https://httpbin.org/get', (res) => {
-          res.setEncoding('utf8')
-          res.on('data', (chunk) => (resBody += chunk))
-          res.on('end', done)
-        })
-        req.end()
-      })
-
-      it('should return original response', () => {
-        expect(resBody).toContain(`\"url\": \"https://httpbin.org/get\"`)
-      })
-    })
-  })
+  expect(res.statusCode).toBe(404)
 })


### PR DESCRIPTION
## Changes

- Implemented `setNoDelay`, `setKeepAlive` and `setTimeout` methods on the `Socket` class.
- Refactored `normalizeHttpRequestParams` to have a better logical flow and to handle partial request options (those without `protocol` and `hostname`, i.e. from `supertest` requests).
- Added unit test for `normalizeHttpRequestParams`

## GitHub

- Fixes #19
- Implements fix for https://github.com/mswjs/msw/issues/209