### PR TITLE
Adds "getUrlByRequestOptions" utility

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -1,5 +1,12 @@
 import { IncomingMessage } from 'http'
 
+// Request instance constructed by the `request` library
+// has a `self` property that has a `uri` field. This is
+// reproducible by performing a `XMLHttpRequest` request (jsdom).
+export interface RequestSelf {
+  uri?: URL
+}
+
 /**
  * A module override function that accepts a request middleware
  * and returns a cleanup function that restores all the patched modules.

--- a/src/http/ClientRequest/normalizeHttpRequestParams.test.ts
+++ b/src/http/ClientRequest/normalizeHttpRequestParams.test.ts
@@ -138,7 +138,9 @@ test('handles [PartialRequestOptions, callback] input', () => {
   )
 
   // URL must be derived from request options
-  expect(url.toJSON()).toEqual(new URL('http://127.0.0.1/resource').toJSON())
+  expect(url.toJSON()).toEqual(
+    new URL('http://127.0.0.1:50176/resource').toJSON()
+  )
 
   // Request options must be preserved
   expect(options).toEqual(initialOptions)

--- a/src/http/ClientRequest/normalizeHttpRequestParams.ts
+++ b/src/http/ClientRequest/normalizeHttpRequestParams.ts
@@ -1,11 +1,9 @@
 import { RequestOptions } from 'https'
 import { HttpRequestCallback, RequestSelf } from '../../glossary'
 import { getRequestOptionsByUrl } from '../../utils/getRequestOptionsByUrl'
+import { getUrlByRequestOptions } from '../../utils/getUrlByRequestOptions'
 
 const debug = require('debug')('http:normalize-http-request-params')
-
-const DEFAULT_PATH = '/'
-const DEFAULT_PROTOCOL = 'http:'
 
 type HttpRequestArgs =
   | [string | URL, HttpRequestCallback?]
@@ -64,18 +62,8 @@ export function normalizeHttpRequestParams(
     options = args[0]
     debug('given request options:', options)
 
-    const path = options.path || DEFAULT_PATH
-
-    if (!options.protocol) {
-      // Assume HTTPS if using an SSL certificate.
-      options.protocol = options.cert ? 'https:' : DEFAULT_PROTOCOL
-    }
-
-    const baseUrl = `${options.protocol}//${options.hostname || options.host}`
-    debug('created base URL:', baseUrl)
-
-    url = options.uri ? new URL(options.uri.href) : new URL(path, baseUrl)
-    debug('created URL:', url)
+    url = getUrlByRequestOptions(options)
+    debug('created a URL:', url)
 
     callback = resolveCallback(args)
   } else {

--- a/src/http/ClientRequest/normalizeHttpRequestParams.ts
+++ b/src/http/ClientRequest/normalizeHttpRequestParams.ts
@@ -1,18 +1,11 @@
 import { RequestOptions } from 'https'
-import { HttpRequestCallback } from '../../glossary'
+import { HttpRequestCallback, RequestSelf } from '../../glossary'
 import { getRequestOptionsByUrl } from '../../utils/getRequestOptionsByUrl'
 
 const debug = require('debug')('http:normalize-http-request-params')
 
 const DEFAULT_PATH = '/'
 const DEFAULT_PROTOCOL = 'http:'
-
-// Request instance constructed by the `request` library
-// has a `self` property that has a `uri` field. This is
-// reproducible by performing a `XMLHttpRequest` request (jsdom).
-interface RequestSelf {
-  uri?: URL
-}
 
 type HttpRequestArgs =
   | [string | URL, HttpRequestCallback?]

--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -1,0 +1,73 @@
+import { getUrlByRequestOptions } from './getUrlByRequestOptions'
+import { RequestOptions } from 'https'
+
+test('returns a URL based on the basic RequestOptions', () => {
+  const options: RequestOptions = {
+    protocol: 'https:',
+    host: '127.0.0.1',
+    path: '/resource',
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('port', '')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+})
+
+test('resolves protocol to "http" given no explicit protocol and no certificate', () => {
+  const options: RequestOptions = {
+    host: '127.0.0.1',
+    path: '/',
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('protocol', 'http:')
+  expect(url).toHaveProperty('port', '')
+  expect(url).toHaveProperty('href', 'http://127.0.0.1/')
+})
+
+test('resolves protocol to "https" given no explicit protocol, but certificate', () => {
+  const options: RequestOptions = {
+    host: '127.0.0.1',
+    path: '/secure',
+    cert: '<!-- SSL certificate -->',
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('protocol', 'https:')
+  expect(url).toHaveProperty('port', '')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1/secure')
+})
+
+test('inherits "port" if given', () => {
+  const options = {
+    protocol: 'http:',
+    host: '127.0.0.1',
+    port: 4002,
+    path: '/',
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('port', '4002')
+  expect(url).toHaveProperty('protocol', 'http:')
+  expect(url).toHaveProperty('href', 'http://127.0.0.1:4002/')
+})
+
+test('inherits "username" and "password"', () => {
+  const options: RequestOptions = {
+    protocol: 'https:',
+    host: '127.0.0.1',
+    path: '/user',
+    auth: 'admin:abc-123',
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('username', 'admin')
+  expect(url).toHaveProperty('password', 'abc-123')
+  expect(url).toHaveProperty('protocol', 'https:')
+  expect(url).toHaveProperty('href', 'https://admin:abc-123@127.0.0.1/user')
+})

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -1,0 +1,35 @@
+import { RequestOptions } from 'https'
+import { RequestSelf } from '../glossary'
+
+const debug = require('debug')('http:get-url-by-request-options')
+
+const DEFAULT_PATH = '/'
+const DEFAULT_PROTOCOL = 'http:'
+
+/**
+ * Creates a `URL` instance from a given `RequestOptions` object.
+ */
+export function getUrlByRequestOptions(
+  options: RequestOptions & RequestSelf
+): URL {
+  const path = options.path || DEFAULT_PATH
+
+  debug('creating URL from options:', debug)
+
+  if (!options.protocol) {
+    debug('given no protocol, resolving...')
+
+    // Assume HTTPS if using an SSL certificate.
+    options.protocol = options.cert ? 'https:' : DEFAULT_PROTOCOL
+
+    debug('resolved protocol to:', options.protocol)
+  }
+
+  const baseUrl = `${options.protocol}//${options.hostname || options.host}`
+  debug('using base URL:', baseUrl)
+
+  const url = options.uri ? new URL(options.uri.href) : new URL(path, baseUrl)
+  debug('created URL:', url)
+
+  return url
+}

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -29,6 +29,17 @@ export function getUrlByRequestOptions(
   debug('using base URL:', baseUrl)
 
   const url = options.uri ? new URL(options.uri.href) : new URL(path, baseUrl)
+
+  if (!!options.port) {
+    url.port = options.port.toString()
+  }
+
+  if (!!options.auth) {
+    const [username, password] = options.auth.split(':')
+    url.username = username
+    url.password = password
+  }
+
   debug('created URL:', url)
 
   return url


### PR DESCRIPTION
## Changes

- Separates the logic that creates a `URL` instance from `RequestOptions` into its own `getUrlByRequestOptions` function.
- Adds support for `options.auth` to be properly transformed into `url.username` and `url.password`.
- Adds support for inheriting `options.port` on the `URL` instance.

## GitHub

- Closes #21