### PR TITLE
Emits request error when middleware throws an exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@open-draft/until": "^1.0.3",
     "debug": "^4.1.1",
     "headers-utils": "^1.2.0"
   },

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -25,7 +25,7 @@ export function httpGet(
   )
 
   return new Promise((resolve, reject) => {
-    http.get(resolvedOptions, (res) => {
+    const req = http.get(resolvedOptions, (res) => {
       res.setEncoding('utf8')
       res.on('data', (chunk) => (resBody += chunk))
       res.on('error', reject)
@@ -33,6 +33,8 @@ export function httpGet(
         resolve({ res, resBody, url, options: resolvedOptions })
       )
     })
+
+    req.on('error', reject)
   })
 }
 
@@ -49,7 +51,7 @@ export function httpsGet(
   )
 
   return new Promise((resolve, reject) => {
-    https.get(resolvedOptions, (res) => {
+    const req = https.get(resolvedOptions, (res) => {
       res.setEncoding('utf8')
       res.on('data', (chunk) => (resBody += chunk))
       res.on('error', reject)
@@ -57,6 +59,8 @@ export function httpsGet(
         resolve({ res, resBody, url, options: resolvedOptions })
       )
     })
+
+    req.on('error', reject)
   })
 }
 

--- a/test/response/http.test.ts
+++ b/test/response/http.test.ts
@@ -18,6 +18,10 @@ beforeAll(() => {
         body: JSON.stringify({ mocked: true }),
       }
     }
+
+    if (req.url.href === 'http://error.me/') {
+      throw new Error('Custom exception message')
+    }
   })
 })
 
@@ -53,6 +57,11 @@ test('bypasses an HTTP request issued by "http.get" not handled in the middlewar
 
   expect(res.statusCode).toBe(200)
   expect(resBody).toContain(`\"url\": \"http://httpbin.org/get\"`)
+})
+
+test('produces a request error when the middleware throws an exception', async () => {
+  const getResponse = () => httpGet('http://error.me')
+  await expect(getResponse()).rejects.toThrow('Custom exception message')
 })
 
 test('bypasses any request when the interceptor is restored', async () => {

--- a/test/response/https.test.ts
+++ b/test/response/https.test.ts
@@ -18,6 +18,10 @@ beforeAll(() => {
         body: JSON.stringify({ mocked: true }),
       }
     }
+
+    if (req.url.href === 'https://error.me/') {
+      throw new Error('Custom exception message')
+    }
   })
 })
 
@@ -53,6 +57,11 @@ test('bypasses an HTTPS request issued by "https.get" not handled in the middlew
 
   expect(res.statusCode).toEqual(200)
   expect(resBody).toContain(`\"url\": \"https://httpbin.org/get\"`)
+})
+
+test('produces a request error when the middleware throws an exception', async () => {
+  const getResponse = () => httpsGet('https://error.me')
+  await expect(getResponse()).rejects.toThrow('Custom exception message')
 })
 
 test('bypasses any request when the interceptor is restored', async () => {

--- a/test/response/xhr.test.ts
+++ b/test/response/xhr.test.ts
@@ -46,6 +46,10 @@ beforeAll(() => {
         body: 'foo',
       }
     }
+
+    if (req.url.href === 'https://error.me/') {
+      throw new Error('Custom exception message')
+    }
   })
 })
 
@@ -89,6 +93,15 @@ test('responds to an HTTP request to a relative URL that is handled in the middl
   expect(res.status).toEqual(301)
   expect(res.headers).toContain('Content-Type: application/hal+json')
   expect(res.body).toEqual('foo')
+})
+
+test('produces a request error when the middleware throws an exception', async () => {
+  const getResponse = async () => {
+    return performXMLHttpRequest('GET', 'https://error.me')
+  }
+
+  // No way to assert the rejection error, because XMLHttpRequest doesn't propagate it.
+  await expect(getResponse()).rejects.toBeTruthy()
 })
 
 test('bypasses any request when the interceptor is restored', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,6 +437,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.2.tgz#505f55c74e0272b43f6c52d81946bed7058fc0e2"


### PR DESCRIPTION
## Changes

- Exception thrown in a middleware function is now gracefully handled as a request (network) error, instead of a process exception. 

## GitHub

- Resolves #28