### PR TITLE
XHR: Invoke listeners attached via "addEventListener"

### DIFF
--- a/src/XMLHttpRequest/XMLHttpRequest/EventOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/EventOverride.ts
@@ -15,6 +15,10 @@ export class EventOverride implements Event {
   public cancelable: boolean = true
   public defaultPrevented: boolean = false
   public bubbles: boolean = true
+  public lengthComputable: boolean = true
+  public loaded: number = 0
+  public total: number = 0
+
   cancelBubble: boolean = false
   returnValue: boolean = true
 

--- a/src/XMLHttpRequest/XMLHttpRequest/createEvent.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/createEvent.ts
@@ -1,6 +1,6 @@
 import { EventOverride } from './EventOverride'
 
-export const createEvent = (options: any, target: any, type: string) => {
+export function createEvent(options: any, target: any, type: string) {
   const progressEvents = [
     'error',
     'progress',

--- a/test/regressions/xhr-add-event-listener.test.ts
+++ b/test/regressions/xhr-add-event-listener.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @see https://github.com/mswjs/msw/issues/273
+ */
+import { RequestInterceptor } from '../../src'
+
+const interceptor = new RequestInterceptor()
+
+beforeAll(() => {
+  interceptor.use((req) => {
+    if (req.url.href === 'https://test.mswjs.io/user') {
+      return {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'x-header': 'yes',
+        },
+        body: JSON.stringify({
+          mocked: true,
+        }),
+      }
+    }
+  })
+})
+
+afterAll(() => {
+  interceptor.restore()
+})
+
+test('calls the "load" event attached via "addEventListener" with a mocked response', (done) => {
+  const xhr = new XMLHttpRequest()
+  function handleResponse(this: XMLHttpRequest) {
+    const { status, responseText } = this
+    const headers = this.getAllResponseHeaders()
+
+    expect(status).toBe(200)
+    expect(headers).toContain('x-header: yes')
+    expect(responseText).toBe(`{"mocked":true}`)
+
+    done()
+  }
+
+  xhr.addEventListener('load', handleResponse)
+  xhr.open('GET', 'https://test.mswjs.io/user')
+  xhr.send()
+})

--- a/test/response/axios.test.ts
+++ b/test/response/axios.test.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios'
+import axios from 'axios'
 import { RequestInterceptor } from '../../src'
 
 let interceptor: RequestInterceptor

--- a/test/response/fetch.test.ts
+++ b/test/response/fetch.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import fetch, { Response } from 'node-fetch'
+import fetch from 'node-fetch'
 import { RequestInterceptor } from '../../src'
 
 let interceptor: RequestInterceptor


### PR DESCRIPTION
## Changes

- Fixes the way listener functions are invoked when attached via `addEventListener` method of `XMLHttpRequest`.
- Provides minor improvements towards event handling in `XMLHttpRequest` override class.
- Adds a regression test to cover that the `load` event attached via `addEventListener` method is properly called with the mocked response (generally, whenever XHR is done).

## GitHub

- Fixes https://github.com/mswjs/msw/issues/273