### PR TITLE
fix: status text in ClientRequestOverride

### DIFF
--- a/src/http/ClientRequest/ClientRequestOverride.ts
+++ b/src/http/ClientRequest/ClientRequestOverride.ts
@@ -184,6 +184,7 @@ export function createClientRequestOverrideClass(
           const { headers = {} } = mockedResponse
 
           response.statusCode = mockedResponse.status
+          response.statusMessage = mockedResponse.statusText
 
           debug('writing response headers...')
 

--- a/test/response/http.test.ts
+++ b/test/response/http.test.ts
@@ -12,6 +12,7 @@ beforeAll(() => {
     if (['http://httpbin.org/'].includes(req.url.href)) {
       return {
         status: 301,
+        statusText: 'Moved Permanently',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -33,6 +34,7 @@ test('responds to an HTTP request issued by "http.request" and handled in the mi
   const { res, resBody } = await httpRequest('http://httpbin.org')
 
   expect(res.statusCode).toBe(301)
+  expect(res.statusMessage).toEqual('Moved Permanently')
   expect(res.headers).toHaveProperty('content-type', 'application/json')
   expect(resBody).toEqual(JSON.stringify({ mocked: true }))
 })
@@ -48,6 +50,7 @@ test('responds to an HTTP request issued by "http.get" and handled in the  middl
   const { res, resBody } = await httpRequest('http://httpbin.org')
 
   expect(res.statusCode).toBe(301)
+  expect(res.statusMessage).toEqual('Moved Permanently')
   expect(res.headers).toHaveProperty('content-type', 'application/json')
   expect(resBody).toEqual(JSON.stringify({ mocked: true }))
 })

--- a/test/response/https.test.ts
+++ b/test/response/https.test.ts
@@ -11,7 +11,8 @@ beforeAll(() => {
   interceptor.use((req) => {
     if (['https://test.mswjs.io'].includes(req.url.origin)) {
       return {
-        status: 301,
+        status: 400,
+        statusText: 'Bad Request',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -32,7 +33,8 @@ afterAll(() => {
 test('responds to an HTTPS request issued by "https.request" and handled in the middleware', async () => {
   const { res, resBody } = await httpsRequest('https://test.mswjs.io')
 
-  expect(res.statusCode).toEqual(301)
+  expect(res.statusCode).toEqual(400)
+  expect(res.statusMessage).toEqual('Bad Request')
   expect(res.headers).toHaveProperty('content-type', 'application/json')
   expect(resBody).toEqual(JSON.stringify({ mocked: true }))
 })
@@ -47,7 +49,8 @@ test('bypasses an HTTPS request issued by "https.request" not handled in the mid
 test('responds to an HTTPS request issued by "https.get" and handled in the middleware', async () => {
   const { res, resBody } = await httpsGet('https://test.mswjs.io')
 
-  expect(res.statusCode).toEqual(301)
+  expect(res.statusCode).toEqual(400)
+  expect(res.statusMessage).toEqual('Bad Request')
   expect(res.headers).toHaveProperty('content-type', 'application/json')
   expect(resBody).toEqual(JSON.stringify({ mocked: true }))
 })


### PR DESCRIPTION
When a request is intercepted by `ClientRequestOverride` the `statusText` from `mockedResponse` was not assigned to real response.

This was the cause of an issue on [MSW](https://github.com/mswjs/msw/issues/279)

I have updated some tests checking the `responseText`