### PR TITLE
Do not load the http overwrite module in react native

### DIFF
--- a/src/RequestInterceptor.ts
+++ b/src/RequestInterceptor.ts
@@ -1,6 +1,5 @@
 import { RequestMiddleware, ModuleOverride } from './glossary'
-import { overrideHttpModule } from './http/override'
-import { overrideXhrModule } from './XMLHttpRequest/override'
+import { overrideModules } from './overrideModules'
 
 const debug = require('debug')('RequestInterceptor')
 
@@ -12,7 +11,7 @@ export class RequestInterceptor {
     this.middleware = []
     debug('created new RequestInterceptor')
 
-    this.overrides = [overrideHttpModule, overrideXhrModule].map((override) =>
+    this.overrides = overrideModules.map((override) =>
       override(this.applyMiddleware)
     )
   }

--- a/src/overrideModules.native.ts
+++ b/src/overrideModules.native.ts
@@ -1,0 +1,3 @@
+import { overrideXhrModule } from './XMLHttpRequest/override'
+
+export const overrideModules = [overrideXhrModule]

--- a/src/overrideModules.ts
+++ b/src/overrideModules.ts
@@ -1,0 +1,4 @@
+import { overrideHttpModule } from './http/override'
+import { overrideXhrModule } from './XMLHttpRequest/override'
+
+export const overrideModules = [overrideHttpModule, overrideXhrModule]


### PR DESCRIPTION
This PR will import different modules when using this package on react-native. Specifically, we don't load `overrideHttpModule`, because the `http` core module is not available on RN.