### PR TITLE
Polyfills "ProgressEvent" for unsupported environments

### DIFF
--- a/src/XMLHttpRequest/XMLHttpRequest/EventOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/EventOverride.ts
@@ -24,11 +24,11 @@ export class EventOverride implements Event {
 
   constructor(
     type: string,
-    overrides?: { target: EventTarget; currentTarget: EventTarget }
+    options?: { target: EventTarget; currentTarget: EventTarget }
   ) {
     this.type = type
-    this.target = overrides?.target || null
-    this.currentTarget = overrides?.currentTarget || null
+    this.target = options?.target || null
+    this.currentTarget = options?.currentTarget || null
     this.timeStamp = Date.now()
   }
 

--- a/src/XMLHttpRequest/XMLHttpRequest/ProgressEventPolyfill.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/ProgressEventPolyfill.ts
@@ -1,0 +1,17 @@
+import { EventOverride } from './EventOverride'
+
+export class ProgressEventPolyfill extends EventOverride {
+  readonly lengthComputable: boolean
+  readonly composed: boolean
+  readonly loaded: number
+  readonly total: number
+
+  constructor(type: string, init?: ProgressEventInit) {
+    super(type)
+
+    this.lengthComputable = init?.lengthComputable || false
+    this.composed = init?.composed || false
+    this.loaded = init?.loaded || 0
+    this.total = init?.total || 0
+  }
+}

--- a/src/XMLHttpRequest/XMLHttpRequest/createEvent.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/createEvent.ts
@@ -1,4 +1,7 @@
 import { EventOverride } from './EventOverride'
+import { ProgressEventPolyfill } from './ProgressEventPolyfill'
+
+const SUPPORTS_PROGRESS_EVENT = typeof ProgressEvent !== 'undefined'
 
 export function createEvent(options: any, target: any, type: string) {
   const progressEvents = [
@@ -11,8 +14,16 @@ export function createEvent(options: any, target: any, type: string) {
     'abort',
   ]
 
+  /**
+   * `ProgressEvent` is not supported in React Native.
+   * @see https://github.com/mswjs/node-request-interceptor/issues/40
+   */
+  const ProgressEventClass = SUPPORTS_PROGRESS_EVENT
+    ? ProgressEvent
+    : ProgressEventPolyfill
+
   const event = progressEvents.includes(type)
-    ? new ProgressEvent(type, {
+    ? new ProgressEventClass(type, {
         lengthComputable: true,
         loaded: options?.loaded || 0,
         total: options?.total || 0,


### PR DESCRIPTION
## Changes

- Adds the `ProgressEventPolyfill` class
- Uses the polyfill class for environments where `ProgressEvent` is not supported (i.e. React Native).

## GitHub

- Fixes #40 