### PR TITLE
Fixes default forwarded XHR.open args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules
 lib
 package-lock.json
+.idea

--- a/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
@@ -51,10 +51,10 @@ export const createXMLHttpRequestOverride = (
     public withCredentials: boolean
     public status: number
     public statusText: string
-    public user: string
-    public password: string
+    public user?: string
+    public password?: string
     public data: string
-    public async: boolean
+    public async?: boolean
     public response: string
     public responseText: string
     public responseType: XMLHttpRequestResponseType
@@ -105,10 +105,7 @@ export const createXMLHttpRequestOverride = (
       this.withCredentials = false
       this.status = 200
       this.statusText = 'OK'
-      this.user = ''
-      this.password = ''
       this.data = ''
-      this.async = true
       this.response = ''
       this.responseType = 'text'
       this.responseText = ''
@@ -176,7 +173,7 @@ export const createXMLHttpRequestOverride = (
     public async open(
       method: string,
       url: string,
-      async?: boolean,
+      async: boolean = true,
       user?: string,
       password?: string
     ) {
@@ -192,9 +189,9 @@ export const createXMLHttpRequestOverride = (
       } else {
         this.url = url
         this.method = method
-        this.async = !!async
-        this.user = user || ''
-        this.password = password || ''
+        this.async = async
+        this.user = user
+        this.password = password
       }
     }
 
@@ -291,7 +288,7 @@ export const createXMLHttpRequestOverride = (
             originalRequest.open(
               this.method,
               this.url,
-              this.async,
+              this.async ?? true,
               this.user,
               this.password
             )

--- a/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
@@ -248,7 +248,7 @@ export const createXMLHttpRequestOverride = (
 
           // Return a mocked response, if provided in the middleware.
           if (mockedResponse) {
-            debug('recieved mocked response', mockedResponse)
+            debug('received mocked response', mockedResponse)
 
             this.status = mockedResponse.status || 200
             this.statusText = mockedResponse.statusText || 'OK'

--- a/src/http/override.ts
+++ b/src/http/override.ts
@@ -49,13 +49,10 @@ function handleRequest(
  */
 export const overrideHttpModule: ModuleOverride = (middleware) => {
   let patchedModules: PatchedModules = {}
-  const modules: ['http', 'https'] = ['http', 'https']
+  const modules = ['http', 'https']
 
   modules.forEach((protocol) => {
-    const module = ({
-      http: require('http'),
-      https: require('https'),
-    } as Record<string, typeof http | typeof https>)[protocol]
+    const module = protocol === 'https' ? https : http
 
     const { request: originalRequest, get: originalGet } = module
 

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -19,8 +19,8 @@ export function getUrlByRequestOptions(
   if (!options.protocol) {
     debug('given no protocol, resolving...')
 
-    // Assume HTTPS if using an SSL certificate.
-    options.protocol = options.cert ? 'https:' : DEFAULT_PROTOCOL
+    // Assume HTTPS if cert is set.
+    options.protocol = options.cert ? 'https:' : (options.uri?.protocol || DEFAULT_PROTOCOL)
 
     debug('resolved protocol to:', options.protocol)
   }

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
@@ -123,7 +123,7 @@ test('intercepts an HTTP PATCH request', async () => {
   expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
 })
 
-test('intercepts an HTTP GET request', async () => {
+test('intercepts an HTTPS GET request', async () => {
   const request = await prepareXHR(
     xhr('GET', 'https://httpbin.org/get?userId=123', {
       headers: {
@@ -199,7 +199,8 @@ test('intercepts an HTTPS DELETE request', async () => {
   expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
 })
 
-test('intercepts an HTTP PATCH request', async () => {
+test('intercepts an HTTPS PATCH request', async () => {
+
   const request = await prepareXHR(
     xhr('PATCH', 'https://httpbin.org/patch?userId=123', {
       headers: {


### PR DESCRIPTION
- `user` and `password` have a default value of `undefined` (previously `''`).
- `async` has a default value of `undefined` (`true` when forwarding) - (previously `false`).
- Removed parameter initializations; set default parameters on `open()`.
- In `getUrlByRequestOptions()`, check if `options.uri.protocol` is set before falling back to `DEFAULT_PROTOCOL`.
- minor cosmetic re-arrangements in ClientRequest interception (imports of http and https modules).
