### PR TITLE
fix: pass timeout to request

### DIFF
--- a/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
@@ -320,11 +320,10 @@ export const createXMLHttpRequestOverride = (
               this.trigger('load')
             }
 
-            // Map callbacks given to the patched instance to the original request instance.
-            originalRequest.onabort = this.abort
-            originalRequest.onerror = this.onerror
-            originalRequest.ontimeout = this.ontimeout
-            originalRequest.onreadystatechange = this.onreadystatechange
+            // Assign callbacks and event listeners from the intercepted XHR instance
+            // to the original XHR instance.
+            this.propagateCallbacks(originalRequest)
+            this.propagateListeners(originalRequest)
 
             if (this.async) {
               originalRequest.timeout = this.timeout
@@ -407,5 +406,25 @@ export const createXMLHttpRequestOverride = (
     }
 
     public overrideMimeType() {}
+
+    /**
+     * Propagates captured XHR instance callbacks to the given XHR instance.
+     * @note that `onload` listener is explicitly omitted.
+     */
+    propagateCallbacks(req: XMLHttpRequest) {
+      req.onabort = this.abort
+      req.onerror = this.onerror
+      req.ontimeout = this.ontimeout
+      req.onloadstart = this.onloadstart
+      req.onloadend = this.onloadend
+      req.onprogress = this.onprogress
+      req.onreadystatechange = this.onreadystatechange
+    }
+
+    propagateListeners(req: XMLHttpRequest) {
+      this._events.forEach(({ name, listener }) => {
+        req.addEventListener(name, listener)
+      })
+    }
   }
 }

--- a/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
+++ b/src/XMLHttpRequest/XMLHttpRequest/createXMLHttpRequestOverride.ts
@@ -326,6 +326,10 @@ export const createXMLHttpRequestOverride = (
             originalRequest.ontimeout = this.ontimeout
             originalRequest.onreadystatechange = this.onreadystatechange
 
+            if (this.async) {
+              originalRequest.timeout = this.timeout
+            }
+
             debug('send', this.data)
             originalRequest.send(this.data)
           }

--- a/test/regressions/xhr-timeout.test.ts
+++ b/test/regressions/xhr-timeout.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @see https://github.com/mswjs/node-request-interceptor/issues/7
+ */
+import { RequestInterceptor } from '../../src'
+
+const interceptor = new RequestInterceptor()
+
+beforeAll(() => {
+  interceptor.use(() => {
+    // Explicitly empty request middleware so that all requests
+    // are bypassed (performed as-is).
+  })
+})
+
+afterAll(() => {
+  interceptor.restore()
+})
+
+test('handles XMLHttpRequest timeout via ontimeout callback', (done) => {
+  const req = new XMLHttpRequest()
+  req.timeout = 1
+  req.ontimeout = function () {
+    expect(this.readyState).toBe(4)
+    done()
+  }
+  req.open('GET', 'http://httpbin.org/get?userId=123', true)
+  req.send()
+})
+
+test('handles XMLHttpRequest timeout via event listener', (done) => {
+  const req = new XMLHttpRequest()
+  req.timeout = 1
+  req.addEventListener('timeout', function () {
+    expect(this.readyState).toBe(4)
+    done()
+  })
+  req.open('GET', 'http://httpbin.org/get?userId=123', true)
+  req.send()
+})


### PR DESCRIPTION
## Changes

- Propagates callbacks (`ontimeout`, `onreadystatechange`, etc.) and event listeners (`timeout`, `error`, etc.) from the captured XHR instance to the original XHR instance.
- Propagates the `timeout` property to the original XHR, so that the request timeout is respected (i.e. when using `axios` with timeout).
- Adds respective tests.

## GitHub

- Originated from https://github.com/mswjs/msw/issues/284
- Fixes #7

Timeout was not passed to original request when no mock response is found.
Hope to did the right thing 😄 

Timeout should be added only if the request is async so when `this.async === true`