### PR TITLE
fix: null value of http.ClientRequest 

### DIFF
--- a/src/interceptors/ClientRequest/ClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/ClientRequestOverride.ts
@@ -249,25 +249,18 @@ export function createClientRequestOverrideClass(
       let req: ClientRequest
       debug('using', performOriginalRequest)
 
-      const { ClientRequest } = http
-
       // Decide whether to use HTTPS based on the URL protocol.
       // XHR can trigger http.request for HTTPS URL.
       if (url.protocol === 'https:') {
         debug('reverting patches...')
+        const { ClientRequest } = http
 
         http.ClientRequest = originalClientRequest
-
-        // Override the global pointer to the original client request.
-        // This way whenever a bypass call bubbles to `handleRequest`
-        // it always performs respecting this `ClientRequest` restoration.
-        originalClientRequest = null as any
 
         req = performOriginalRequest(options)
 
         debug('re-applying patches...')
         http.ClientRequest = ClientRequest
-        originalClientRequest = ClientRequest
       } else {
         req = performOriginalRequest(options)
       }

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -106,11 +106,6 @@ export const interceptClientRequest: Interceptor = (middleware) => {
   return () => {
     debug('restoring patches...')
 
-    //restore the original ClientReqest if it was overridden
-    if (originalClientRequest) {
-      http.ClientRequest = originalClientRequest
-      originalClientRequest = null as any
-    }
     Object.values(patchedModules).forEach(({ module, request, get }) => {
       module.request = request
       module.get = get

--- a/test/response/fetch.test.ts
+++ b/test/response/fetch.test.ts
@@ -7,7 +7,7 @@ import withDefaultInterceptors from '../../src/presets/default'
 
 let interceptor: RequestInterceptor
 
-beforeAll(() => {
+beforeEach(() => {
   interceptor = new RequestInterceptor(withDefaultInterceptors)
   interceptor.use((req) => {
     if (
@@ -26,7 +26,7 @@ beforeAll(() => {
   })
 })
 
-afterAll(() => {
+afterEach(() => {
   interceptor.restore()
 })
 
@@ -79,4 +79,15 @@ test('bypasses any request when the interceptor is restored', async () => {
   const httpsBody = await httpsRes.json()
   expect(httpsRes.status).toEqual(200)
   expect(httpsBody).toHaveProperty('url', 'https://httpbin.org/get')
+})
+
+test('should not throw error if there are multiple interceptors', async () => {
+  const secondInterceptor = new RequestInterceptor(withDefaultInterceptors)
+  let res = await fetch('https://httpbin.org/get')
+  let body = await res.json()
+
+  expect(res.status).toEqual(200)
+  expect(body).toHaveProperty('url', 'https://httpbin.org/get')
+
+  secondInterceptor.restore()
 })


### PR DESCRIPTION
The PR will fix https://github.com/mswjs/node-request-interceptor/issues/49

The problem was that on next when you make an hard refresh the old instance of `RequestInterceptor` was not cleared.
This behavior could cause an issue because the `http.ClientRequest` sometime was null.

I don't know if we should allow the user to create multiple `RequestInterceptor` on the same interceptors 🤔 