### PR TITLE
XMLHttpRequest: Handles middleware exceptions with error event first, then abort

### DIFF
--- a/src/interceptors/ClientRequest/ClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/ClientRequestOverride.ts
@@ -170,7 +170,7 @@ export function createClientRequestOverrideClass(
       // When the request middleware throws an exception, error the request.
       // This cancels the request and is similar to a network error.
       if (middlewareException) {
-        debug('middleware function threw an exception!')
+        debug('middleware function threw an exception!', middlewareException)
         this.emit('error', middlewareException)
 
         return this

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -237,7 +237,10 @@ export const createXMLHttpRequestOverride = (
           // When the request middleware throws an exception, error the request.
           // This cancels the request and is similar to a network error.
           if (middlewareException) {
-            debug('middleware function threw an exception!')
+            debug(
+              'middleware function threw an exception!',
+              middlewareException
+            )
 
             this.abort()
             // No way to propagate the actual error message.

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -242,9 +242,9 @@ export const createXMLHttpRequestOverride = (
               middlewareException
             )
 
-            this.abort()
             // No way to propagate the actual error message.
             this.trigger('error')
+            this.abort()
 
             return
           }

--- a/test/regressions/xhr-middleware-exception.test.ts
+++ b/test/regressions/xhr-middleware-exception.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @see https://github.com/mswjs/msw/issues/355
+ */
+import fetch from 'node-fetch'
+import axios from 'axios'
+import { RequestInterceptor } from '../../src'
+import withDefaultInterceptors from '../../src/presets/default'
+
+let interceptor: RequestInterceptor
+
+beforeAll(() => {
+  interceptor = new RequestInterceptor(withDefaultInterceptors)
+  interceptor.use(() => {
+    throw new Error('Custom error message')
+  })
+})
+
+afterAll(() => {
+  interceptor.restore()
+})
+
+test('propagates a custom error message to the fetch request error', () => {
+  fetch('https://test.mswjs.io').catch((error) => {
+    expect(error).toHaveProperty(
+      'message',
+      'request to https://test.mswjs.io/ failed, reason: Custom error message'
+    )
+  })
+})
+
+test('causes a Network Error when using axios', () => {
+  axios.get('https://test.mswjs.io').catch((error) => {
+    /**
+     * axios always treats request exceptions with the fixed "Network Error" message.
+     * @see https://github.com/axios/axios/issues/383
+     */
+    expect(error).toHaveProperty('message', 'Network Error')
+  })
+})


### PR DESCRIPTION
## Changes

- Improves debugging of interceptors by including the actual middleware exception reference in the `debug` call.
- Ensures that NRI first emits the `error` event and then aborts the XMLHttpRequest.

## GitHub

- Provides a solution for https://github.com/mswjs/msw/issues/355