### PR TITLE
Resolve protocol from agent, if set

### DIFF
--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -1,5 +1,5 @@
 import { getUrlByRequestOptions } from './getUrlByRequestOptions'
-import { RequestOptions } from 'https'
+import { RequestOptions, Agent } from 'https'
 
 test('returns a URL based on the basic RequestOptions', () => {
   const options: RequestOptions = {
@@ -12,6 +12,20 @@ test('returns a URL based on the basic RequestOptions', () => {
   expect(url).toBeInstanceOf(URL)
   expect(url).toHaveProperty('port', '')
   expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+})
+
+test('resolves protocol from agent, if one exists', () => {
+  const options: RequestOptions = {
+    host: '127.0.0.1',
+    path: '/',
+    agent: new Agent()
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('protocol', 'https:')
+  expect(url).toHaveProperty('port', '')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1/')
 })
 
 test('resolves protocol to "http" given no explicit protocol and no certificate', () => {

--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -1,5 +1,6 @@
+import { Agent as HttpAgent } from 'http'
+import { RequestOptions, Agent as HttpsAgent } from 'https'
 import { getUrlByRequestOptions } from './getUrlByRequestOptions'
-import { RequestOptions, Agent } from 'https'
 
 test('returns a URL based on the basic RequestOptions', () => {
   const options: RequestOptions = {
@@ -14,18 +15,34 @@ test('returns a URL based on the basic RequestOptions', () => {
   expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
 })
 
-test('resolves protocol from agent, if one exists', () => {
+test('inherits protocol and port from http.Agent, if set', () => {
   const options: RequestOptions = {
     host: '127.0.0.1',
     path: '/',
-    agent: new Agent()
+    agent: new HttpAgent(),
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('protocol', 'http:')
+  expect(url).toHaveProperty('port', '')
+  expect(url).toHaveProperty('href', 'http://127.0.0.1/')
+})
+
+test('inherits protocol and port from https.Agent, if set', () => {
+  const options: RequestOptions = {
+    host: '127.0.0.1',
+    path: '/',
+    agent: new HttpsAgent({
+      port: 3080,
+    }),
   }
   const url = getUrlByRequestOptions(options)
 
   expect(url).toBeInstanceOf(URL)
   expect(url).toHaveProperty('protocol', 'https:')
-  expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1/')
+  expect(url).toHaveProperty('port', '3080')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1:3080/')
 })
 
 test('resolves protocol to "http" given no explicit protocol and no certificate', () => {

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -16,6 +16,8 @@ export function getUrlByRequestOptions(
 
   debug('creating URL from options:', options)
 
+  options.protocol = options.protocol || (options.agent && (options.agent as RequestOptions).protocol) || undefined
+
   if (!options.protocol) {
     debug('given no protocol, resolving...')
 

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -1,3 +1,4 @@
+import { Agent } from 'http'
 import { RequestOptions } from 'https'
 import { RequestSelf } from '../glossary'
 
@@ -16,13 +17,18 @@ export function getUrlByRequestOptions(
 
   debug('creating URL from options:', options)
 
-  options.protocol = options.protocol || (options.agent && (options.agent as RequestOptions).protocol) || undefined
+  // Inherit the protocol from the Agent, if present.
+  if (options.agent instanceof Agent) {
+    options.protocol = (options.agent as RequestOptions).protocol
+  }
 
   if (!options.protocol) {
     debug('given no protocol, resolving...')
 
     // Assume HTTPS if cert is set.
-    options.protocol = options.cert ? 'https:' : (options.uri?.protocol || DEFAULT_PROTOCOL)
+    options.protocol = options.cert
+      ? 'https:'
+      : options.uri?.protocol || DEFAULT_PROTOCOL
 
     debug('resolved protocol to:', options.protocol)
   }


### PR DESCRIPTION
In `normalizeHttpRequestParams`, the protocol is taken from the url, if there is none set in the options https://github.com/mswjs/node-request-interceptor/blob/09ec3011638131f9b06b63d106c762ab0d59d9f9/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts#L81

As the comment above the code states, this is to avoid an error of mismatching protocols, from this section of the node code https://github.com/nodejs/node/blob/d84f1312915fe45fe0febe888db692c74894c382/lib/_http_client.js#L142-L145

In the same code, we can see that the expected protocol comes from `this.agent`, if set and lines 125 and 140 show us that this will be the agent that is set in the options, if any exists.

Therefore in order to avoid the error when this is set, we should set the url protocol to match this one (from the url returned here https://github.com/mswjs/node-request-interceptor/blob/09ec3011638131f9b06b63d106c762ab0d59d9f9/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts#L67)

As we default to http when there is no protocol or certificate, if we have an https agent set, but no protocol set on the options, we will have `options.agent.protocol=https:` and `url.protocol=http:`, then when we set options protocol from the url one (https://github.com/mswjs/node-request-interceptor/blob/09ec3011638131f9b06b63d106c762ab0d59d9f9/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts#L81) we will also have `options.protocol=http:`, which gives us the mismatching protocol error in the node js code.