### PR TITLE
Support legacy Url objects

### DIFF
--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
@@ -1,5 +1,5 @@
 import { RequestOptions } from 'https'
-import { Url as LegacyURL } from 'url';
+import { Url as LegacyURL } from 'url'
 import { HttpRequestCallback, RequestSelf } from '../../../glossary'
 import { getRequestOptionsByUrl } from '../../../utils/getRequestOptionsByUrl'
 import { getUrlByRequestOptions } from '../../../utils/getUrlByRequestOptions'
@@ -68,37 +68,42 @@ export function normalizeHttpRequestParams(
 
     callback = resolveCallback(args)
   }
-  // Handle a legacy Url and re-normalize from either a RequestOptions object
-  // or a WHATWG URL
+  // Handle a legacy URL instance and re-normalize from either a RequestOptions object
+  // or a WHATWG URL.
   else if ('hash' in args[0] && !('method' in args[0])) {
-    if (args[0].hostname === null) {
-      /*
-        We are dealing with a relative url, so use the path as an "option" and
-        merge-in any existing options, giving priority to exising options -- i.e. a path in any
-        existing options will take precedence over the one contained in the url. This is consistent
-        with the behaviour in ClientRequest.
-        
-        https://github.com/nodejs/node/blob/d84f1312915fe45fe0febe888db692c74894c382/lib/_http_client.js#L122
-      */
-      debug('given a relative legacy url:', args[0])
+    const [legacyUrl] = args
+
+    if (legacyUrl.hostname === null) {
+      // We are dealing with a relative url, so use the path as an "option" and
+      // merge in any existing options, giving priority to exising options -- i.e. a path in any
+      // existing options will take precedence over the one contained in the url. This is consistent
+      // with the behaviour in ClientRequest.
+      // https://github.com/nodejs/node/blob/d84f1312915fe45fe0febe888db692c74894c382/lib/_http_client.js#L122
+      debug('given a relative legacy URL:', legacyUrl)
 
       return isObject(args[1])
-        ? normalizeHttpRequestParams({path: args[0].path, ...args[1]}, args[2])
-        : normalizeHttpRequestParams({path: args[0].path}, args[1] as HttpRequestCallback)
+        ? normalizeHttpRequestParams(
+            { path: legacyUrl.path, ...args[1] },
+            args[2]
+          )
+        : normalizeHttpRequestParams(
+            { path: legacyUrl.path },
+            args[1] as HttpRequestCallback
+          )
     }
 
-    debug('given an absolute legacy url:', args[0])
+    debug('given an absolute legacy url:', legacyUrl)
 
-    //We are dealing with an absolute url, so convert to WHATWG and try again
-    const resolvedUrl = new URL(args[0].href)
+    // We are dealing with an absolute URL, so convert to WHATWG and try again.
+    const resolvedUrl = new URL(legacyUrl.href)
 
     return args[1] === undefined
       ? normalizeHttpRequestParams(resolvedUrl)
       : typeof args[1] === 'function'
-        ? normalizeHttpRequestParams(resolvedUrl, args[1])
-        : normalizeHttpRequestParams(resolvedUrl, args[1], args[2])
+      ? normalizeHttpRequestParams(resolvedUrl, args[1])
+      : normalizeHttpRequestParams(resolvedUrl, args[1], args[2])
   }
-  // Handle a given request options object as-is
+  // Handle a given RequestOptions object as-is
   // and derive the URL instance from it.
   else if (isObject(args[0])) {
     options = args[0]

--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
@@ -18,7 +18,7 @@ function resolveRequestOptions(
 ): RequestOptions {
   // Calling `fetch` provides only URL to ClientRequest,
   // without RequestOptions or callback.
-  if (!isRequestOptions(args[1])) {
+  if (['function', 'undefined'].includes(typeof args[1])) {
     return getRequestOptionsByUrl(url)
   }
 
@@ -29,10 +29,6 @@ function resolveCallback(
   args: HttpRequestArgs
 ): HttpRequestCallback | undefined {
   return typeof args[1] === 'function' ? args[1] : args[2]
-}
-
-function isRequestOptions(arg?: RequestOptions|HttpRequestCallback): boolean {
-  return !['function', 'undefined'].includes(typeof arg);
 }
 
 /**
@@ -86,7 +82,7 @@ export function normalizeHttpRequestParams(
       */
       debug('given a relative legacy url:', args[0])
 
-      return isRequestOptions(args[1])
+      return isObject(args[1])
         ? normalizeHttpRequestParams({path: args[0].path, ...args[1]}, args[2])
         : normalizeHttpRequestParams({path: args[0].path}, args[1] as HttpRequestCallback)
     }

--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
@@ -1,5 +1,5 @@
 import { RequestOptions } from 'https'
-import { Url } from 'url';
+import { Url as LegacyURL } from 'url';
 import { HttpRequestCallback, RequestSelf } from '../../../glossary'
 import { getRequestOptionsByUrl } from '../../../utils/getRequestOptionsByUrl'
 import { getUrlByRequestOptions } from '../../../utils/getUrlByRequestOptions'
@@ -8,8 +8,8 @@ import { isObject } from '../../../utils/isObject'
 const debug = require('debug')('http normalizeHttpRequestParams')
 
 type HttpRequestArgs =
-  | [string | URL | Url, HttpRequestCallback?]
-  | [string | URL | Url, RequestOptions, HttpRequestCallback?]
+  | [string | URL | LegacyURL, HttpRequestCallback?]
+  | [string | URL | LegacyURL, RequestOptions, HttpRequestCallback?]
   | [RequestOptions, HttpRequestCallback?]
 
 function resolveRequestOptions(

--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
@@ -90,7 +90,13 @@ export function normalizeHttpRequestParams(
     debug('given an absolute legacy url:', args[0])
 
     //We are dealing with an absolute url, so convert to WHATWG and try again
-    return normalizeHttpRequestParams(...[new URL(args[0].href), ...args.slice(1)] as HttpRequestArgs)
+    const resolvedUrl = new URL(args[0].href)
+
+    return args[1] === undefined
+      ? normalizeHttpRequestParams(resolvedUrl)
+      : typeof args[1] === 'function'
+        ? normalizeHttpRequestParams(resolvedUrl, args[1])
+        : normalizeHttpRequestParams(resolvedUrl, args[1], args[2])
   }
   // Handle a given request options object as-is
   // and derive the URL instance from it.


### PR DESCRIPTION
In addition to the WHATWG `URL` object, node js also has a legacy `Url` object, created through `url.parse`, which is accepted when creating http requests. Although this type is deprecated as of node 11, there are many packages which are using it.

This change is to allow interoperability with a wider range of packages by normalising the legacy Url to a WHATWG URL.