### PR TITLE
Allow request options to be empty and default hostname to 'localhost'

### DIFF
--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.test.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.test.ts
@@ -116,6 +116,16 @@ test('handles [RequestOptions, callback] input', () => {
   expect(callback).toHaveProperty('name', 'cb')
 })
 
+test('handles [Empty RequestOptions, callback] input', () => {
+  const [_, __, callback] = normalizeHttpRequestParams(
+    {},
+    function cb() {}
+  )
+
+  // Callback must be preserved
+  expect(callback).toHaveProperty('name', 'cb')
+})
+
 /**
  * @see https://github.com/mswjs/node-request-interceptor/issues/19
  */

--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
@@ -60,7 +60,7 @@ export function normalizeHttpRequestParams(
     debug('created request options', options)
 
     callback = resolveCallback(args)
-  } else if ('method' in args[0]) {
+  } else if (Object.prototype.toString.call(args[0]) === '[object Object]') {
     options = args[0]
     debug('given request options:', options)
 

--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
@@ -2,6 +2,7 @@ import { RequestOptions } from 'https'
 import { HttpRequestCallback, RequestSelf } from '../../../glossary'
 import { getRequestOptionsByUrl } from '../../../utils/getRequestOptionsByUrl'
 import { getUrlByRequestOptions } from '../../../utils/getUrlByRequestOptions'
+import { isObject } from '../../../utils/isObject'
 
 const debug = require('debug')('http normalizeHttpRequestParams')
 
@@ -42,6 +43,8 @@ export function normalizeHttpRequestParams(
 
   debug('arguments', args)
 
+  // Convert a url string into a URL instance
+  // and derive request options from it.
   if (typeof args[0] === 'string') {
     debug('given a location string:', args[0])
 
@@ -52,7 +55,10 @@ export function normalizeHttpRequestParams(
     debug('created request options:', options)
 
     callback = resolveCallback(args)
-  } else if ('origin' in args[0]) {
+  }
+  // Handle a given URL instance as-is
+  // and derive request options from it.
+  else if ('origin' in args[0]) {
     url = args[0]
     debug('given a URL:', url)
 
@@ -60,7 +66,10 @@ export function normalizeHttpRequestParams(
     debug('created request options', options)
 
     callback = resolveCallback(args)
-  } else if (Object.prototype.toString.call(args[0]) === '[object Object]') {
+  }
+  // Handle a given request options object as-is
+  // and derive the URL instance from it.
+  else if (isObject(args[0])) {
     options = args[0]
     debug('given request options:', options)
 

--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -102,3 +102,11 @@ test('inherits "username" and "password"', () => {
   expect(url).toHaveProperty('protocol', 'https:')
   expect(url).toHaveProperty('href', 'https://admin:abc-123@127.0.0.1/user')
 })
+
+test('resolves hostname to localhost if none provided', () => {
+  const url = getUrlByRequestOptions({})
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('protocol', 'http:')
+  expect(url).toHaveProperty('href', 'http://localhost/')
+})

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -7,6 +7,7 @@ const debug = require('debug')('utils getUrlByRequestOptions')
 
 export const DEFAULT_PATH = '/'
 const DEFAULT_PROTOCOL = 'http:'
+const DEFAULT_HOST = 'localhost'
 const DEFAULT_PORT = 80
 
 /**
@@ -43,7 +44,9 @@ export function getUrlByRequestOptions(
     debug('resolved protocol to:', options.protocol)
   }
 
-  const baseUrl = `${options.protocol}//${options.hostname || options.host}`
+  const baseUrl = `${options.protocol}//${
+    options.hostname || options.host || DEFAULT_HOST
+  }`
   debug('using base URL:', baseUrl)
 
   const url = options.uri ? new URL(options.uri.href) : new URL(path, baseUrl)

--- a/src/utils/isObject.test.ts
+++ b/src/utils/isObject.test.ts
@@ -1,0 +1,19 @@
+import { isObject } from './isObject'
+
+test('resolves given an object', () => {
+  expect(isObject({})).toBe(true)
+  expect(isObject({ a: 1 })).toBe(true)
+})
+
+test('rejects given an object-like instance', () => {
+  expect(isObject([1])).toBe(false)
+  expect(isObject(function () {})).toBe(false)
+})
+
+test('rejects given a non-object instance', () => {
+  expect(isObject(null)).toBe(false)
+  expect(isObject(undefined)).toBe(false)
+  expect(isObject(false)).toBe(false)
+  expect(isObject(123)).toBe(false)
+  expect(isObject(Symbol('object Object'))).toBe(false)
+})

--- a/src/utils/isObject.ts
+++ b/src/utils/isObject.ts
@@ -1,0 +1,6 @@
+/**
+ * Determines if a given value is an instance of object.
+ */
+export function isObject(value: any): boolean {
+  return Object.prototype.toString.call(value) === '[object Object]'
+}


### PR DESCRIPTION
The `RequestOptions` object does not have any required properties, therefore we should not rely on `method` for its identification. Any object should be accepted as request options.

Since the hostname and host are also optional, we should not rely on either of them being set when constructing the URL. If node cannot find any set in hostname or host, then it defaults to `localhost` (https://github.com/nodejs/node/blob/d84f1312915fe45fe0febe888db692c74894c382/lib/_http_client.js#L163)

In order to retain parity, the default hostname should be this when creating the URL.