### PR TITLE
Test that https module defaults to https protocol

### DIFF
--- a/test/response/https.test.ts
+++ b/test/response/https.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+import { request } from 'https';
 import { RequestInterceptor } from '../../src'
 import { httpsGet, httpsRequest } from '../helpers'
 import withDefaultInterceptors from '../../src/presets/default'
@@ -59,6 +60,35 @@ test('bypasses an HTTPS request issued by "https.request" not handled in the mid
 
   expect(res.statusCode).toEqual(200)
   expect(resBody).toEqual('/get')
+})
+
+test('Correctly handles an HTTPS request issued by "https.request" from options without protocol', async () => {
+  try {
+    await new Promise((resolve, reject) => {
+      const rejectError = (error: Error) => {
+        reject(error)
+      }
+  
+      const req = request({
+        host: server.getHttpsServerHostName(),
+        port: server.getHttpsServerPort(),
+        path: '/get'
+      }, (res) => {
+        res.on('error', rejectError)
+  
+        res.on('end', () => {
+          resolve()
+        })
+      })
+  
+      req.on('error', rejectError)
+  
+      req.end()
+    })
+  } catch (error) {
+    // If we get a message about a bad certificate, then node was happy with the protocol
+    expect(error.message).toMatch(/certificate/i)
+  }
 })
 
 test('responds to an HTTPS request issued by "https.get" and handled in the middleware', async () => {


### PR DESCRIPTION
At the moment this is just a PR with a failing test that illustrates the problem, as I would like some suggestions as to the best solution.

The problem is that at the moment, we resolve the correct protocol in the `normalizeHttpRequestParams` method (well actually in one of the small functions it depends on). By the time we reach this stage, we have lost any context of which module we are normalising for, but this is important information, as node js will use this to determine the default protocol when handling `RequestOptions` that does not contain any protocol information.

For example, in the unpatched versions

`require('https').request({host: 'www.banana.com', path: '/cherry'})` will resolve to `https://www.banana.com/cherry`

whereas

`require('http').request({host: 'www.banana.com', path: '/cherry'})` will resolve to `http://www.banana.com/cherry`

Although I have not included it in my test case, similar is true of the port. The https module will default to 443 and the http module will default to 80. This is explained here https://nodejs.org/api/https.html#https_https_request_url_options_callback

If we handle this in `normalizeHttpRequestParams`, then it means passing the context down through the existing layers. If we choose to handle this further up, where we have the context already, it means determining the nature of the arguments further up (since we need to know which if any of the arguments are the `RequestOptions`).

I've created this issue https://github.com/mswjs/node-request-interceptor/issues/67, but I think the discussion would be better here. What do you guys think?

UPDATE:

So, I've implemented a solution that involves passing the protocol context down the layers, which can be seen here https://github.com/sean-hernon/node-request-interceptor/pull/2/files.

@kettanaito What do you think about proceeding with this implementation? If we want to go this way then I can update _this_ branch with the solution. 