### PR TITLE
XHR: Respects "responseType" when resolving response body

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -434,7 +434,18 @@ export const createXMLHttpRequestOverride = (
     getResponseBody(body: string = '') {
       switch (this.responseType) {
         case 'json':
+          debug('resolving response body as JSON')
           return parseJson(body)
+
+        case 'blob':
+          const blobType =
+            this.getResponseHeader('content-type') || 'text/plain'
+          debug('resolving response body as Blob', { type: blobType })
+
+          return new Blob([body], {
+            type: blobType,
+          })
+
         default:
           return body
       }

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -260,6 +260,9 @@ export const createXMLHttpRequestOverride = (
               ? flattenHeadersObject(mockedResponse.headers)
               : {}
 
+            debug('assigned response status', this.status, this.statusText)
+            debug('assigned response headers', this.responseHeaders)
+
             // Mark that response headers has been received
             // and trigger a ready state event to reflect received headers
             // in a custom `onreadystatechange` callback.
@@ -268,6 +271,9 @@ export const createXMLHttpRequestOverride = (
 
             this.response = this.getResponseBody(mockedResponse.body)
             this.responseText = mockedResponse.body || ''
+
+            debug('response type', this.responseType)
+            debug('assigned response body', this.response)
 
             // Trigger a progress event based on the mocked response body.
             this.trigger('progress', {
@@ -366,7 +372,21 @@ export const createXMLHttpRequestOverride = (
         return null
       }
 
-      return this.responseHeaders[name.toLowerCase()] || null
+      const headerValue = Object.entries(this.responseHeaders).reduce<
+        string | null
+      >((_, [headerName, headerValue]) => {
+        // Ignore header name casing while still allowing to set response headers
+        // with an arbitrary casing (no normalization).
+        if ([headerName, headerName.toLowerCase()].includes(name)) {
+          return headerValue
+        }
+
+        return null
+      }, null)
+
+      debug('resolved response header', name, headerValue, this.responseHeaders)
+
+      return headerValue
     }
 
     public getAllResponseHeaders(): string {

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -433,11 +433,12 @@ export const createXMLHttpRequestOverride = (
      */
     getResponseBody(body: string = '') {
       switch (this.responseType) {
-        case 'json':
+        case 'json': {
           debug('resolving response body as JSON')
           return parseJson(body)
+        }
 
-        case 'blob':
+        case 'blob': {
           const blobType =
             this.getResponseHeader('content-type') || 'text/plain'
           debug('resolving response body as Blob', { type: blobType })
@@ -445,12 +446,14 @@ export const createXMLHttpRequestOverride = (
           return new Blob([body], {
             type: blobType,
           })
+        }
 
-        case 'arraybuffer':
+        case 'arraybuffer': {
           debug('resolving response body as ArrayBuffer')
           const buffer = Buffer.from(body)
           const arrayBuffer = new Uint8Array(buffer)
           return arrayBuffer
+        }
 
         default:
           return body

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -9,6 +9,7 @@ import {
   HeadersObject,
 } from 'headers-utils'
 import { RequestMiddleware, InterceptedRequest } from '../../glossary'
+import { parseJson } from '../../utils/parseJson'
 import { createEvent } from './helpers/createEvent'
 
 const createDebug = require('debug')
@@ -55,7 +56,7 @@ export const createXMLHttpRequestOverride = (
     public password?: string
     public data: string
     public async?: boolean
-    public response: string
+    public response: any
     public responseText: string
     public responseType: XMLHttpRequestResponseType
     public responseXML: Document | null
@@ -265,7 +266,7 @@ export const createXMLHttpRequestOverride = (
             this.readyState = this.HEADERS_RECEIVED
             this.triggerReadyStateChange()
 
-            this.response = mockedResponse.body || ''
+            this.response = this.getResponseBody(mockedResponse.body)
             this.responseText = mockedResponse.body || ''
 
             // Trigger a progress event based on the mocked response body.
@@ -406,6 +407,18 @@ export const createXMLHttpRequestOverride = (
     }
 
     public overrideMimeType() {}
+
+    /**
+     * Sets a proper `response` property based on the `responseType` value.
+     */
+    getResponseBody(body: string = '') {
+      switch (this.responseType) {
+        case 'json':
+          return parseJson(body)
+        default:
+          return body
+      }
+    }
 
     /**
      * Propagates captured XHR instance callbacks to the given XHR instance.

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -269,10 +269,10 @@ export const createXMLHttpRequestOverride = (
             this.readyState = this.HEADERS_RECEIVED
             this.triggerReadyStateChange()
 
+            debug('response type', this.responseType)
             this.response = this.getResponseBody(mockedResponse.body)
             this.responseText = mockedResponse.body || ''
 
-            debug('response type', this.responseType)
             debug('assigned response body', this.response)
 
             // Trigger a progress event based on the mocked response body.
@@ -445,6 +445,12 @@ export const createXMLHttpRequestOverride = (
           return new Blob([body], {
             type: blobType,
           })
+
+        case 'arraybuffer':
+          debug('resolving response body as ArrayBuffer')
+          const buffer = Buffer.from(body)
+          const arrayBuffer = new Uint8Array(buffer)
+          return arrayBuffer
 
         default:
           return body

--- a/src/utils/parseJson.test.ts
+++ b/src/utils/parseJson.test.ts
@@ -1,0 +1,9 @@
+import { parseJson } from './parseJson'
+
+test('parses a given string into JSON', () => {
+  expect(parseJson('{"id":1}')).toEqual({ id: 1 })
+})
+
+test('returns null given invalid JSON string', () => {
+  expect(parseJson('{"o:2\'')).toBeNull()
+})

--- a/src/utils/parseJson.ts
+++ b/src/utils/parseJson.ts
@@ -1,0 +1,12 @@
+/**
+ * Parses a given string into JSON.
+ * Gracefully handles invalid JSON by returning `null`.
+ */
+export function parseJson(data: string): Record<string, any> | null {
+  try {
+    const json = JSON.parse(data)
+    return json
+  } catch (_) {
+    return null
+  }
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -212,3 +212,17 @@ export async function prepare(
   const { url, options } = await promise
   return findRequest(pool, options.method, url)
 }
+
+export async function readBlob(
+  blob: Blob
+): Promise<string | ArrayBuffer | null> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.addEventListener('loadend', () => {
+      resolve(reader.result)
+    })
+    reader.addEventListener('abort', reject)
+    reader.addEventListener('error', reject)
+    reader.readAsText(blob)
+  })
+}

--- a/test/regressions/xhr-response-type.test.ts
+++ b/test/regressions/xhr-response-type.test.ts
@@ -1,0 +1,45 @@
+import { RequestInterceptor } from '../../src'
+import withDefaultInterceptors from '../../src/presets/default'
+
+let requestInterceptor: RequestInterceptor
+
+beforeAll(() => {
+  requestInterceptor = new RequestInterceptor(withDefaultInterceptors)
+  requestInterceptor.use((req) => {
+    return {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        firstName: 'John',
+        lastName: 'Maverick',
+      }),
+    }
+  })
+})
+
+afterAll(() => {
+  requestInterceptor.restore()
+})
+
+test('responds with an object when "responseType" equals "json"', (done) => {
+  const req = new XMLHttpRequest()
+  req.open('GET', '/arbitrary-url')
+  req.responseType = 'json'
+
+  req.addEventListener('loadend', () => {
+    const { readyState, response } = req
+
+    if (readyState === 4) {
+      expect(typeof response).toBe('object')
+      expect(response).toEqual({
+        firstName: 'John',
+        lastName: 'Maverick',
+      })
+
+      done()
+    }
+  })
+
+  req.send()
+})

--- a/test/regressions/xhr-response-type.test.ts
+++ b/test/regressions/xhr-response-type.test.ts
@@ -86,3 +86,31 @@ test('responds with a Blob when "responseType" equals "blob"', (done) => {
 
   req.send()
 })
+
+test('responds with an ArrayBuffer when "responseType" equals "arraybuffer"', (done) => {
+  const req = new XMLHttpRequest()
+  req.open('GET', '/arbitrary-url')
+  req.responseType = 'arraybuffer'
+
+  const expectedArrayBuffer = new Uint8Array(
+    Buffer.from(
+      JSON.stringify({
+        firstName: 'John',
+        lastName: 'Maverick',
+      })
+    )
+  )
+
+  req.addEventListener('loadend', () => {
+    const { readyState, response } = req
+
+    if (readyState === 4) {
+      const responseBuffer: Uint8Array = response
+
+      expect(Buffer.compare(responseBuffer, expectedArrayBuffer)).toBe(0)
+      done()
+    }
+  })
+
+  req.send()
+})


### PR DESCRIPTION
## Changes

- `XMLHttpRequest` override now respects the `req.responseType` property when setting a mocked response body as the value of the `response` property.
- Supported `responseType` values:
  - `text` (default). Returns mocked response body as-is (response body is always set as text).
  - `json`. Attempts to parse the mocked body as JSON. Returns `null` if parsing fails. 
  - `blob`. Returns a `Blob` from the mocked response body.
  - `arraybuffer`. Returns an `Unit8Array` instance from the mocked response body.

## GitHub

- Fixes #69