### PR TITLE
Handles empty response body in XMLHttpRequest progress event

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -431,11 +431,15 @@ export const createXMLHttpRequestOverride = (
     /**
      * Sets a proper `response` property based on the `responseType` value.
      */
-    getResponseBody(body: string = '') {
+    getResponseBody(body: string | undefined) {
+      // Handle an improperly set "null" value of the mocked response body.
+      const textBody = body ?? ''
+      debug('coerced response body to', textBody)
+
       switch (this.responseType) {
         case 'json': {
           debug('resolving response body as JSON')
-          return parseJson(body)
+          return parseJson(textBody)
         }
 
         case 'blob': {
@@ -443,20 +447,20 @@ export const createXMLHttpRequestOverride = (
             this.getResponseHeader('content-type') || 'text/plain'
           debug('resolving response body as Blob', { type: blobType })
 
-          return new Blob([body], {
+          return new Blob([textBody], {
             type: blobType,
           })
         }
 
         case 'arraybuffer': {
           debug('resolving response body as ArrayBuffer')
-          const buffer = Buffer.from(body)
+          const buffer = Buffer.from(textBody)
           const arrayBuffer = new Uint8Array(buffer)
           return arrayBuffer
         }
 
         default:
-          return body
+          return textBody
       }
     }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -155,8 +155,11 @@ export async function fetch(
 }
 
 interface PromisifiedXhrPayload {
+  status: number
+  statusText: string
   method: string
   url: string
+  body: any
 }
 
 export async function xhr(
@@ -171,9 +174,15 @@ export async function xhr(
     const req = new XMLHttpRequest()
     req.open(method, url)
 
-    req.onload = function () {
-      resolve({ method, url })
-    }
+    req.addEventListener('load', () => {
+      resolve({
+        method,
+        url,
+        body: req.response,
+        status: req.status,
+        statusText: req.statusText,
+      })
+    })
 
     if (options?.headers) {
       Object.entries(options.headers).forEach(([name, value]) => {
@@ -184,7 +193,9 @@ export async function xhr(
       })
     }
 
-    req.onerror = reject
+    req.addEventListener('error', reject)
+    req.addEventListener('abort', reject)
+
     req.send(options?.body)
   })
 }

--- a/test/regressions/xhr-response-empty-body.test.ts
+++ b/test/regressions/xhr-response-empty-body.test.ts
@@ -1,0 +1,40 @@
+import { RequestInterceptor } from '../../src'
+import withDefaultInterceptors from '../../src/presets/default'
+
+let interceptor: RequestInterceptor
+
+beforeAll(() => {
+  interceptor = new RequestInterceptor(withDefaultInterceptors)
+  interceptor.use(() => {
+    return {
+      status: 401,
+      // @ts-nocheck JavaScript clients and type-casting may
+      // circument the mocked response body type signature,
+      // setting in invalid value.
+      body: null as any,
+    }
+  })
+})
+
+afterAll(() => {
+  interceptor.restore()
+})
+
+test('supports XHR mocked response with an empty response body', () => {
+  const req = new XMLHttpRequest()
+  req.responseType = 'text'
+  req.open('GET', '/arbitrary-url')
+  req.send()
+
+  return new Promise((resolve, reject) => {
+    req.addEventListener('error', reject)
+    req.addEventListener('abort', reject)
+
+    req.addEventListener('load', () => {
+      expect(req.status).toEqual(401)
+      expect(req.response).toBe('')
+
+      resolve()
+    })
+  })
+})


### PR DESCRIPTION
## GitHub

- Fixes #71 

## Changes

- Ensures that the body input of `XMLHttpRequest.getResponseBody` always operates on at least an empty string. Sometimes it may receive a `null` as a value, for example:

```js
// No explicit response body means "body: null" on the MSW side
res(ctx.status(403)
```

Default mocked response object declaring `body: null` as the default mocked response body value:
https://github.com/mswjs/msw/blob/33022cdecb6c979b5e2963dc88aaa2b886d7adba/src/response.ts#L46-L52