### PR TITLE
Adds utility to dispatch XHR as promises

### DIFF
--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -243,7 +243,18 @@ export function createXMLHttpRequest(
 ): Promise<XMLHttpRequest> {
   const req = new XMLHttpRequest()
   middleware(req)
-  req.send()
+
+  if (req.readyState < 1) {
+    throw new Error(
+      'Failed to create an XMLHttpRequest. Did you forget to call `req.open()` in the middleware function?'
+    )
+  }
+
+  if (req.readyState < 2) {
+    // Send the request only if it hasn't been sent
+    // as a part of the middleware function.
+    req.send()
+  }
 
   return new Promise((resolve, reject) => {
     req.addEventListener('loadend', () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -154,52 +154,6 @@ export async function fetch(
   }
 }
 
-interface PromisifiedXhrPayload {
-  status: number
-  statusText: string
-  method: string
-  url: string
-  body: any
-}
-
-export async function xhr(
-  method: string,
-  url: string,
-  options?: {
-    body?: string
-    headers?: Record<string, string | string[]>
-  }
-): Promise<PromisifiedXhrPayload> {
-  return new Promise((resolve, reject) => {
-    const req = new XMLHttpRequest()
-    req.open(method, url)
-
-    req.addEventListener('load', () => {
-      resolve({
-        method,
-        url,
-        body: req.response,
-        status: req.status,
-        statusText: req.statusText,
-      })
-    })
-
-    if (options?.headers) {
-      Object.entries(options.headers).forEach(([name, value]) => {
-        req.setRequestHeader(
-          name,
-          Array.isArray(value) ? value.join('; ') : value
-        )
-      })
-    }
-
-    req.addEventListener('error', reject)
-    req.addEventListener('abort', reject)
-
-    req.send(options?.body)
-  })
-}
-
 export function findRequest(
   pool: InterceptedRequest[],
   method: string = 'GET',

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -237,3 +237,20 @@ export async function readBlob(
     reader.readAsText(blob)
   })
 }
+
+export function createXMLHttpRequest(
+  middleware: (req: XMLHttpRequest) => void
+): Promise<XMLHttpRequest> {
+  const req = new XMLHttpRequest()
+  middleware(req)
+  req.send()
+
+  return new Promise((resolve, reject) => {
+    req.addEventListener('loadend', () => {
+      resolve(req)
+    })
+
+    req.addEventListener('error', reject)
+    req.addEventListener('abort', reject)
+  })
+}

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
@@ -2,16 +2,15 @@ import { RequestHandler } from 'express'
 import { RequestInterceptor } from '../../../src'
 import withDefaultInterceptors from '../../../src/presets/default'
 import { InterceptedRequest } from '../../../src/glossary'
-import { xhr, findRequest } from '../../helpers'
+import { findRequest, createXMLHttpRequest } from '../../helpers'
 import { ServerAPI, createServer } from '../../utils/createServer'
 
-function prepareXHR(
-  res: ReturnType<typeof xhr>,
+function lookupRequest(
+  req: XMLHttpRequest,
+  method: string,
   pool: InterceptedRequest[]
-): Promise<InterceptedRequest | undefined> {
-  return res.then(({ url, method }) => {
-    return findRequest(pool, method, url)
-  })
+): InterceptedRequest | undefined {
+  return findRequest(pool, method, req.responseURL)
 }
 
 let requestInterceptor: RequestInterceptor
@@ -52,221 +51,233 @@ afterAll(async () => {
 })
 
 test('intercepts an HTTP GET request', async () => {
-  const request = await prepareXHR(
-    xhr('GET', server.makeHttpUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', server.makeHttpUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'GET', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'GET')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'GET')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTP POST request', async () => {
-  const request = await prepareXHR(
-    xhr('POST', server.makeHttpUrl('/user?id=123'), {
-      body: 'request-body',
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('POST', server.makeHttpUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+    req.send('request-body')
+  })
+  const interceptedReq = lookupRequest(req, 'POST', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'POST')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request).toHaveProperty('body', 'request-body')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'POST')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('body', 'request-body')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTP PUT request', async () => {
-  const request = await prepareXHR(
-    xhr('PUT', server.makeHttpUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('PUT', server.makeHttpUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'PUT', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'PUT')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'PUT')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTP DELETE request', async () => {
-  const request = await prepareXHR(
-    xhr('DELETE', server.makeHttpUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('DELETE', server.makeHttpUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'DELETE', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'DELETE')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'DELETE')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTP PATCH request', async () => {
-  const request = await prepareXHR(
-    xhr('PATCH', server.makeHttpUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('PATCH', server.makeHttpUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'PATCH', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'PATCH')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'PATCH')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTP HEAD request', async () => {
-  const request = await prepareXHR(
-    xhr('HEAD', server.makeHttpUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('HEAD', server.makeHttpUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'HEAD', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'HEAD')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'HEAD')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTPS GET request', async () => {
-  const request = await prepareXHR(
-    xhr('GET', server.makeHttpsUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', server.makeHttpsUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'GET', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpsUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'GET')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpsUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'GET')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTPS POST request', async () => {
-  const request = await prepareXHR(
-    xhr('POST', server.makeHttpsUrl('/user?id=123'), {
-      body: 'request-body',
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('POST', server.makeHttpsUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+    req.send('request-body')
+  })
+  const interceptedReq = lookupRequest(req, 'POST', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpsUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'POST')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request).toHaveProperty('body', 'request-body')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpsUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'POST')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('body', 'request-body')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTPS PUT request', async () => {
-  const request = await prepareXHR(
-    xhr('PUT', server.makeHttpsUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('PUT', server.makeHttpsUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'PUT', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpsUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'PUT')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpsUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'PUT')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTPS DELETE request', async () => {
-  const request = await prepareXHR(
-    xhr('DELETE', server.makeHttpsUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('DELETE', server.makeHttpsUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'DELETE', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpsUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'DELETE')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpsUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'DELETE')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTPS PATCH request', async () => {
-  const request = await prepareXHR(
-    xhr('PATCH', server.makeHttpsUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('PATCH', server.makeHttpsUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'PATCH', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpsUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'PATCH')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpsUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'PATCH')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })
 
 test('intercepts an HTTPS HEAD request', async () => {
-  const request = await prepareXHR(
-    xhr('HEAD', server.makeHttpsUrl('/user?id=123'), {
-      headers: {
-        'x-custom-header': 'yes',
-      },
-    }),
-    pool
-  )
+  const req = await createXMLHttpRequest((req) => {
+    req.open('HEAD', server.makeHttpsUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const interceptedReq = lookupRequest(req, 'HEAD', pool)
 
-  expect(request).toBeTruthy()
-  expect(request?.url).toBeInstanceOf(URL)
-  expect(request?.url.toString()).toEqual(server.makeHttpsUrl('/user?id=123'))
-  expect(request).toHaveProperty('method', 'HEAD')
-  expect(request?.url.searchParams.get('id')).toEqual('123')
-  expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+  expect(interceptedReq).toBeTruthy()
+  expect(interceptedReq?.url).toBeInstanceOf(URL)
+  expect(interceptedReq?.url.toString()).toEqual(
+    server.makeHttpsUrl('/user?id=123')
+  )
+  expect(interceptedReq).toHaveProperty('method', 'HEAD')
+  expect(interceptedReq?.url.searchParams.get('id')).toEqual('123')
+  expect(interceptedReq).toHaveProperty('headers', {
+    'x-custom-header': 'yes',
+  })
 })

--- a/test/regressions/xhr-add-event-listener.test.ts
+++ b/test/regressions/xhr-add-event-listener.test.ts
@@ -3,6 +3,7 @@
  */
 import { RequestInterceptor } from '../../src'
 import withDefaultInterceptors from '../../src/presets/default'
+import { createXMLHttpRequest } from '../helpers'
 
 let interceptor: RequestInterceptor
 
@@ -28,20 +29,16 @@ afterAll(() => {
   interceptor.restore()
 })
 
-test('calls the "load" event attached via "addEventListener" with a mocked response', (done) => {
-  const xhr = new XMLHttpRequest()
-  function handleResponse(this: XMLHttpRequest) {
-    const { status, responseText } = this
-    const headers = this.getAllResponseHeaders()
+test('calls the "load" event attached via "addEventListener" with a mocked response', async () => {
+  await createXMLHttpRequest((req) => {
+    req.open('GET', 'https://test.mswjs.io/user')
+    req.addEventListener('load', function () {
+      const { status, responseText } = this
+      const headers = this.getAllResponseHeaders()
 
-    expect(status).toBe(200)
-    expect(headers).toContain('x-header: yes')
-    expect(responseText).toBe(`{"mocked":true}`)
-
-    done()
-  }
-
-  xhr.addEventListener('load', handleResponse)
-  xhr.open('GET', 'https://test.mswjs.io/user')
-  xhr.send()
+      expect(status).toBe(200)
+      expect(headers).toContain('x-header: yes')
+      expect(responseText).toBe(`{"mocked":true}`)
+    })
+  })
 })

--- a/test/regressions/xhr-response-empty-body.test.ts
+++ b/test/regressions/xhr-response-empty-body.test.ts
@@ -1,5 +1,6 @@
 import { RequestInterceptor } from '../../src'
 import withDefaultInterceptors from '../../src/presets/default'
+import { createXMLHttpRequest } from '../helpers'
 
 let interceptor: RequestInterceptor
 
@@ -20,21 +21,11 @@ afterAll(() => {
   interceptor.restore()
 })
 
-test('supports XHR mocked response with an empty response body', () => {
-  const req = new XMLHttpRequest()
-  req.responseType = 'text'
-  req.open('GET', '/arbitrary-url')
-  req.send()
-
-  return new Promise((resolve, reject) => {
-    req.addEventListener('error', reject)
-    req.addEventListener('abort', reject)
-
-    req.addEventListener('load', () => {
-      expect(req.status).toEqual(401)
-      expect(req.response).toBe('')
-
-      resolve()
-    })
+test('supports XHR mocked response with an empty response body', async () => {
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', '/arbitrary-url')
   })
+
+  expect(req.status).toBe(401)
+  expect(req.response).toBe('')
 })

--- a/test/regressions/xhr-timeout.test.ts
+++ b/test/regressions/xhr-timeout.test.ts
@@ -3,6 +3,7 @@
  */
 import { RequestInterceptor } from '../../src'
 import withDefaultInterceptors from '../../src/presets/default'
+import { createXMLHttpRequest } from '../helpers'
 
 let interceptor: RequestInterceptor
 
@@ -18,24 +19,26 @@ afterAll(() => {
   interceptor.restore()
 })
 
-test('handles XMLHttpRequest timeout via ontimeout callback', (done) => {
-  const req = new XMLHttpRequest()
-  req.timeout = 1
-  req.ontimeout = function () {
-    expect(this.readyState).toBe(4)
-    done()
-  }
-  req.open('GET', 'http://httpbin.org/get?userId=123', true)
-  req.send()
+test('handles XMLHttpRequest timeout via ontimeout callback', async () => {
+  expect.assertions(1)
+
+  await createXMLHttpRequest((req) => {
+    req.open('GET', 'http://httpbin.org/get?userId=123', true)
+    req.timeout = 1
+    req.addEventListener('timeout', function () {
+      expect(this.readyState).toBe(4)
+    })
+  })
 })
 
-test('handles XMLHttpRequest timeout via event listener', (done) => {
-  const req = new XMLHttpRequest()
-  req.timeout = 1
-  req.addEventListener('timeout', function () {
-    expect(this.readyState).toBe(4)
-    done()
+test('handles XMLHttpRequest timeout via event listener', async () => {
+  expect.assertions(1)
+
+  await createXMLHttpRequest((req) => {
+    req.open('GET', 'http://httpbin.org/get?userId=123', true)
+    req.timeout = 1
+    req.addEventListener('timeout', function () {
+      expect(this.readyState).toBe(4)
+    })
   })
-  req.open('GET', 'http://httpbin.org/get?userId=123', true)
-  req.send()
 })

--- a/test/response/xhr.test.ts
+++ b/test/response/xhr.test.ts
@@ -1,34 +1,7 @@
 import { RequestInterceptor } from '../../src'
 import withDefaultInterceptors from '../../src/presets/default'
+import { createXMLHttpRequest } from '../helpers'
 import { ServerAPI, createServer } from '../utils/createServer'
-
-interface XhrResponse {
-  status: number
-  headers: string
-  body: string
-}
-
-function performXMLHttpRequest(
-  method: string,
-  url: string
-): Promise<XhrResponse> {
-  return new Promise((resolve, reject) => {
-    const req = new XMLHttpRequest()
-    let status: number
-    let headers: string
-    let body: string
-
-    req.onload = () => {
-      body = req.response
-      headers = req.getAllResponseHeaders()
-      status = req.status
-      resolve({ status, headers, body })
-    }
-    req.onerror = reject
-    req.open(method, url)
-    req.send()
-  })
-}
 
 let interceptor: RequestInterceptor
 let server: ServerAPI
@@ -76,46 +49,61 @@ afterAll(async () => {
 })
 
 test('responds to an HTTP request handled in the middleware', async () => {
-  const res = await performXMLHttpRequest('GET', server.makeHttpUrl('/'))
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', server.makeHttpUrl('/'))
+  })
+  const responseHeaders = req.getAllResponseHeaders()
 
-  expect(res.status).toEqual(301)
-  expect(res.headers).toContain('Content-Type: application/hal+json')
-  expect(res.body).toEqual('foo')
+  expect(req.status).toEqual(301)
+  expect(responseHeaders).toContain('Content-Type: application/hal+json')
+  expect(req.response).toEqual('foo')
 })
 
 test('bypasses an HTTP request not handled in the middleware', async () => {
-  const res = await performXMLHttpRequest('GET', server.makeHttpUrl('/get'))
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', server.makeHttpUrl('/get'))
+  })
 
-  expect(res.status).toEqual(200)
-  expect(res.body).toEqual('/get')
+  expect(req.status).toEqual(200)
+  expect(req.response).toEqual('/get')
 })
 
 test('responds to an HTTPS request handled in the middleware', async () => {
-  const res = await performXMLHttpRequest('GET', server.makeHttpsUrl('/'))
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', server.makeHttpsUrl('/'))
+  })
+  const responseHeaders = req.getAllResponseHeaders()
 
-  expect(res.status).toEqual(301)
-  expect(res.headers).toContain('Content-Type: application/hal+json')
-  expect(res.body).toEqual('foo')
+  expect(req.status).toEqual(301)
+  expect(responseHeaders).toContain('Content-Type: application/hal+json')
+  expect(req.response).toEqual('foo')
 })
 
 test('bypasses an HTTPS request not handled in the middleware', async () => {
-  const res = await performXMLHttpRequest('GET', server.makeHttpsUrl('/get'))
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', server.makeHttpsUrl('/get'))
+  })
 
-  expect(res.status).toEqual(200)
-  expect(res.body).toEqual('/get')
+  expect(req.status).toEqual(200)
+  expect(req.response).toEqual('/get')
 })
 
 test('responds to an HTTP request to a relative URL that is handled in the middleware', async () => {
-  const res = await performXMLHttpRequest('POST', '/login')
+  const req = await createXMLHttpRequest((req) => {
+    req.open('POST', server.makeHttpsUrl('/login'))
+  })
+  const responseHeaders = req.getAllResponseHeaders()
 
-  expect(res.status).toEqual(301)
-  expect(res.headers).toContain('Content-Type: application/hal+json')
-  expect(res.body).toEqual('foo')
+  expect(req.status).toEqual(301)
+  expect(responseHeaders).toContain('Content-Type: application/hal+json')
+  expect(req.response).toEqual('foo')
 })
 
 test('produces a request error when the middleware throws an exception', async () => {
   const getResponse = () => {
-    return performXMLHttpRequest('GET', 'https://error.me')
+    return createXMLHttpRequest((req) => {
+      req.open('GET', 'https://error.me')
+    })
   }
 
   // No way to assert the rejection error, because XMLHttpRequest doesn't propagate it.
@@ -124,8 +112,10 @@ test('produces a request error when the middleware throws an exception', async (
 
 test('bypasses any request when the interceptor is restored', async () => {
   interceptor.restore()
-  const res = await performXMLHttpRequest('GET', server.makeHttpsUrl('/'))
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', server.makeHttpsUrl('/'))
+  })
 
-  expect(res.status).toEqual(200)
-  expect(res.body).toEqual('/')
+  expect(req.status).toEqual(200)
+  expect(req.response).toEqual('/')
 })


### PR DESCRIPTION
- Allows creation and handling of `XMLHttpRequest` as promises.
- Supports full customizability of XHR via the middleware function.
- Enforces to treat the XHR response as an actual XHR response, not a custom abstraction. Makes tests more friendly to people unfamiliar with the internal abstractions. 
