### PR TITLE
determine secure protocol by 443 port

### DIFF
--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -82,7 +82,7 @@ test('resolves protocol to "https" given no explicit protocol, but port is 443',
 
   expect(url).toBeInstanceOf(URL)
   expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1:443/resource')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
 })
 
 test('inherits "port" if given', () => {

--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -85,19 +85,6 @@ test('resolves protocol to "https" given no explicit protocol, but port is 443',
   expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
 })
 
-test('resolves protocol to "https" given no explicit protocol, but port is 443', () => {
-  const options: RequestOptions = {
-    host: '127.0.0.1',
-    port: 443,
-    path: '/resource',
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
-})
-
 test('resolves protocol to "https" given no explicit protocol, but agent port is 443', () => {
   const options: RequestOptions = {
     host: '127.0.0.1',

--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -85,6 +85,34 @@ test('resolves protocol to "https" given no explicit protocol, but port is 443',
   expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
 })
 
+test('resolves protocol to "https" given no explicit protocol, but port is 443', () => {
+  const options: RequestOptions = {
+    host: '127.0.0.1',
+    port: 443,
+    path: '/resource',
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('port', '')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+})
+
+test('resolves protocol to "https" given no explicit protocol, but agent port is 443', () => {
+  const options: RequestOptions = {
+    host: '127.0.0.1',
+    agent: new HttpsAgent({
+      port: 443,
+    }),
+    path: '/resource',
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('port', '')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+})
+
 test('inherits "port" if given', () => {
   const options = {
     protocol: 'http:',

--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -72,6 +72,19 @@ test('resolves protocol to "https" given no explicit protocol, but certificate',
   expect(url).toHaveProperty('href', 'https://127.0.0.1/secure')
 })
 
+test('resolves protocol to "https" given no explicit protocol, but port is 443', () => {
+  const options: RequestOptions = {
+    host: '127.0.0.1',
+    port: 443,
+    path: '/resource',
+  }
+  const url = getUrlByRequestOptions(options)
+
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toHaveProperty('port', '443')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+})
+
 test('inherits "port" if given', () => {
   const options = {
     protocol: 'http:',

--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -81,8 +81,8 @@ test('resolves protocol to "https" given no explicit protocol, but port is 443',
   const url = getUrlByRequestOptions(options)
 
   expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('port', '443')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+  expect(url).toHaveProperty('port', '')
+  expect(url).toHaveProperty('href', 'https://127.0.0.1:443/resource')
 })
 
 test('inherits "port" if given', () => {

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -32,7 +32,9 @@ function getProtocolByRequestOptions(
     return agentProtocol
   }
 
-  const isSecureRequest = options.cert || options.port === SSL_PORT
+  const port = getPortByRequestOptions(options)
+
+  const isSecureRequest = options.cert || port === SSL_PORT
 
   return isSecureRequest ? 'https:' : options.uri?.protocol || DEFAULT_PROTOCOL
 }

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -10,6 +10,7 @@ export const DEFAULT_PATH = '/'
 const DEFAULT_PROTOCOL = 'http:'
 const DEFAULT_HOST = 'localhost'
 const DEFAULT_PORT = 80
+const SSL_PORT = 443
 
 function getAgent(
   options: IsomorphicRequestOptions
@@ -31,7 +32,9 @@ function getProtocolByRequestOptions(
     return agentProtocol
   }
 
-  return options.cert ? 'https:' : options.uri?.protocol || DEFAULT_PROTOCOL
+  const isSecureRequest = options.cert || options.port === SSL_PORT
+
+  return isSecureRequest ? 'https:' : options.uri?.protocol || DEFAULT_PROTOCOL
 }
 
 function getPortByRequestOptions(


### PR DESCRIPTION
Relates to issue on [msw #486](https://github.com/mswjs/msw/issues/486).

When port is 443 use the secure https protocol.