### PR TITLE
XMLHttpRequest: Handles "progress" event on omni-value response body

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -275,11 +275,17 @@ export const createXMLHttpRequestOverride = (
 
             debug('assigned response body', this.response)
 
-            // Trigger a progress event based on the mocked response body.
-            this.trigger('progress', {
-              loaded: this.response.length,
-              total: this.response.length,
-            })
+            if (mockedResponse.body && this.response) {
+              // Presense of the mocked response implies a response body (not null).
+              // Presece of the coerced `this.response` implies the mocked body is valid.
+              const bodyBuffer = Buffer.from(mockedResponse.body)
+
+              // Trigger a progress event based on the mocked response body.
+              this.trigger('progress', {
+                loaded: bodyBuffer.length,
+                total: bodyBuffer.length,
+              })
+            }
 
             // Explicitly mark the request as done, so its response never hangs.
             // @see https://github.com/mswjs/node-request-interceptor/issues/13

--- a/test/regressions/xhr-response-invalid-json-body.test.ts
+++ b/test/regressions/xhr-response-invalid-json-body.test.ts
@@ -1,0 +1,55 @@
+import { RequestInterceptor } from '../../src'
+import withDefaultInterceptors from '../../src/presets/default'
+import { createXMLHttpRequest } from '../helpers'
+
+let interceptor: RequestInterceptor
+
+beforeAll(() => {
+  interceptor = new RequestInterceptor(withDefaultInterceptors)
+  interceptor.use((req) => {
+    switch (req.url.pathname) {
+      case '/no-body': {
+        return {
+          status: 204,
+        }
+      }
+
+      case '/invalid-json': {
+        return {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: `{"invalid: js'on`,
+        }
+      }
+    }
+  })
+})
+
+afterAll(() => {
+  interceptor.restore()
+})
+
+test('handles response of type "json" and missing response JSON body', async () => {
+  const req = await createXMLHttpRequest((req) => {
+    req.open('PUT', '/no-body')
+    req.responseType = 'json'
+  })
+
+  // When XHR fails to parse a given response JSON body,
+  // fall back to null, as the failed JSON parsing result.
+  expect(req).toHaveProperty('response', null)
+  expect(req).toHaveProperty('responseText', '')
+  expect(req).toHaveProperty('responseType', 'json')
+})
+
+test('handles response of type "json" and invalid response JSON body', async () => {
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', '/invalid-json')
+    req.responseType = 'json'
+  })
+
+  expect(req).toHaveProperty('response', null)
+  expect(req).toHaveProperty('responseText', `{"invalid: js'on`)
+  expect(req).toHaveProperty('responseType', 'json')
+})


### PR DESCRIPTION
## GitHub

- Fixes https://github.com/mswjs/msw/issues/487

## Changes

- The `progress` event of `XMLHttpRequest` now fires only when the mocked response body was set (there's a body to load), and the coerced response body according to `responseType` is present (coercion was successful, the mocked response body is valid against the specified `responseType`). 
- The `progress` event now converts the raw mocked response body (string) into a `Buffer`, to handle various body types (string, JSON, ArrayBuffer, Blob) and determine their length.
- Adds a test to assert missing/invalid response body handling of an `XMLHttpRequest` with `responseType = 'json'`. Actual XHR behavior was taken for the reference. 