### PR TITLE
Fix two memory leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@open-draft/until": "^1.0.3",
-    "debug": "^4.1.1",
+    "debug": "^4.3.0",
     "headers-utils": "^1.2.0"
   },
   "keywords": [

--- a/src/interceptors/ClientRequest/ClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/ClientRequestOverride.ts
@@ -190,9 +190,9 @@ export function createClientRequestOverrideClass(
 
           // Converts mocked response headers to actual headers
           // (lowercases header names and merges duplicates).
-          response.headers = Object.entries(headers).reduce<
-            http.IncomingHttpHeaders
-          >((acc, [name, value]) => {
+          response.headers = Object.entries(
+            headers
+          ).reduce<http.IncomingHttpHeaders>((acc, [name, value]) => {
             const headerName = name.toLowerCase()
             const headerValue = acc.hasOwnProperty(headerName)
               ? ([] as string[]).concat(acc[headerName] as string, value)
@@ -329,7 +329,7 @@ export function createClientRequestOverrideClass(
     return this
   }
 
-  inherits(ClientRequestOverride, http.ClientRequest)
+  inherits(ClientRequestOverride, originalClientRequest)
 
   return ClientRequestOverride
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,13 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2820,7 +2827,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.1.1:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==


### PR DESCRIPTION
1st leak comes from Debug module, when debug instances are created within a function. For more info: https://github.com/visionmedia/debug/issues/678

2nd leak is caused by `createClientRequestOverrideClass`, when `handleRequest` is called multiple times (check screenshot below). It inherits `ClientRequestOverride` from a previous `ClientRequestOverride` instance:
- `http.ClientRequest = ClientRequestOverride`
https://github.com/mswjs/node-request-interceptor/blob/728822439966cd06e67948e3bea370377d098177/src/interceptors/ClientRequest/index.ts#L33-L41
- next calls wrap `ClientRequestOverride` which wraps `ClientRequestOverride` which wraps `ClientRequestOverride` etc.
https://github.com/mswjs/node-request-interceptor/blob/728822439966cd06e67948e3bea370377d098177/src/interceptors/ClientRequest/ClientRequestOverride.ts#L332

Maybe I'm missing something and you intentionally inherited it from `http.ClientRequest` instead of `originalClientRequest`?

![image](https://user-images.githubusercontent.com/4675984/101454283-46f5ee00-3963-11eb-90fe-8c8d35531070.png)

