### PR TITLE
Adds a "response" event

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "@open-draft/until": "^1.0.3",
     "debug": "^4.3.0",
-    "headers-utils": "^1.2.0"
+    "headers-utils": "^1.2.0",
+    "strict-event-emitter": "^0.1.0"
   },
   "keywords": [
     "request",

--- a/src/RequestInterceptor.ts
+++ b/src/RequestInterceptor.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events'
+import { StrictEventEmitter } from 'strict-event-emitter'
 import {
   Interceptor,
   RequestInterceptorEventsMap,
@@ -9,11 +9,11 @@ const debug = require('debug')('RequestInterceptor')
 
 export class RequestInterceptor {
   private interceptors: ReturnType<Interceptor>[]
-  private emitter: EventEmitter
+  private emitter: StrictEventEmitter<RequestInterceptorEventsMap>
   private middleware: RequestMiddleware[]
 
   constructor(interceptors: Interceptor[]) {
-    this.emitter = new EventEmitter()
+    this.emitter = new StrictEventEmitter<RequestInterceptorEventsMap>()
     this.middleware = []
     debug('created new RequestInterceptor', { interceptors })
 

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events'
 import { IncomingMessage } from 'http'
 
 // Request instance constructed by the `request` library
@@ -7,11 +8,18 @@ export interface RequestSelf {
   uri?: URL
 }
 
+export interface RequestInterceptorContext {
+  emitter: EventEmitter
+}
+
 /**
  * A module override function that accepts a request middleware
  * and returns a cleanup function that restores all the patched modules.
  */
-export type Interceptor = (middleware: RequestMiddleware) => () => void
+export type Interceptor = (
+  middleware: RequestMiddleware,
+  context: RequestInterceptorContext
+) => () => void
 
 export type HttpRequestCallback = (res: IncomingMessage) => void
 
@@ -34,4 +42,8 @@ export interface MockedResponse {
   statusText: string
   headers: Record<string, string | string[]>
   body: string
+}
+
+export interface RequestInterceptorEventsMap {
+  response: (req: InterceptedRequest, res: Partial<MockedResponse>) => void
 }

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'events'
 import { IncomingMessage } from 'http'
+import { StrictEventEmitter } from 'strict-event-emitter'
 
 // Request instance constructed by the `request` library
 // has a `self` property that has a `uri` field. This is
@@ -9,7 +9,7 @@ export interface RequestSelf {
 }
 
 export interface RequestInterceptorContext {
-  emitter: EventEmitter
+  emitter: StrictEventEmitter<RequestInterceptorEventsMap>
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ export { getCleanUrl } from './utils/getCleanUrl'
 /* Typings */
 export {
   Interceptor,
+  RequestInterceptorContext,
+  RequestInterceptorEventsMap,
   RequestMiddleware,
   InterceptedRequest,
   MockedResponse,

--- a/src/interceptors/ClientRequest/ClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/ClientRequestOverride.ts
@@ -7,6 +7,7 @@ import {
   RequestMiddleware,
   InterceptedRequest,
   RequestInterceptorContext,
+  MockedResponse,
 } from '../../glossary'
 import { SocketPolyfill } from './polyfills/SocketPolyfill'
 
@@ -294,7 +295,7 @@ export function createClientRequestOverrideClass(
         context.emitter.emit('response', formattedRequest, {
           status: response.statusCode,
           statusText: response.statusMessage,
-          headers: response.headers,
+          headers: response.headers as MockedResponse['headers'],
           body: await getIncomingMessageBody(response),
         })
       })

--- a/src/interceptors/ClientRequest/ClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/ClientRequestOverride.ts
@@ -293,14 +293,15 @@ export function createClientRequestOverrideClass(
         debug(response.statusCode, options.method, url.href)
         this.emit('response', response)
 
-        context.emitter.emit('response', formattedRequest, {
-          status: response.statusCode,
-          statusText: response.statusMessage,
-          headers: response.headers,
-          /**
-           * @todo Retreive the response body.
-           */
-          body: '???',
+        let responseBody = ''
+        response.on('data', (chunk) => (responseBody += chunk))
+        response.on('end', () => {
+          context.emitter.emit('response', formattedRequest, {
+            status: response.statusCode,
+            statusText: response.statusMessage,
+            headers: response.headers,
+            body: responseBody,
+          })
         })
       })
 

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -1,6 +1,10 @@
 import http from 'http'
 import https from 'https'
-import { Interceptor, RequestMiddleware } from '../../glossary'
+import {
+  Interceptor,
+  RequestInterceptorContext,
+  RequestMiddleware,
+} from '../../glossary'
 import { createClientRequestOverrideClass } from './ClientRequestOverride'
 
 const debug = require('debug')('http override')
@@ -22,6 +26,7 @@ function handleRequest(
   protocol: string,
   originalMethod: any,
   middleware: RequestMiddleware,
+  context: RequestInterceptorContext,
   args: any[]
 ): http.ClientRequest {
   //The first time we execute this, I'll save the original ClientRequest.
@@ -32,6 +37,7 @@ function handleRequest(
 
   const ClientRequestOverride = createClientRequestOverrideClass(
     middleware,
+    context,
     originalMethod,
     originalClientRequest
   )
@@ -49,7 +55,7 @@ function handleRequest(
 /**
  * Intercepts requests issued by native `http` and `https` modules.
  */
-export const interceptClientRequest: Interceptor = (middleware) => {
+export const interceptClientRequest: Interceptor = (middleware, context) => {
   let patchedModules: PatchedModules = {}
   const modules = ['http', 'https']
 
@@ -77,6 +83,7 @@ export const interceptClientRequest: Interceptor = (middleware) => {
         protocol,
         proxiedOriginalRequest.bind(requestModule),
         middleware,
+        context,
         args
       )
     }
@@ -89,6 +96,7 @@ export const interceptClientRequest: Interceptor = (middleware) => {
         protocol,
         originalGet.bind(requestModule),
         middleware,
+        context,
         args
       )
       req.end()

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
@@ -1,0 +1,13 @@
+import { IncomingMessage } from 'http'
+
+export function getIncomingMessageBody(res: IncomingMessage): Promise<string> {
+  let responseBody = ''
+
+  return new Promise((resolve, reject) => {
+    res.once('error', reject)
+    res.on('data', (chunk) => (responseBody += chunk))
+    res.once('end', () => {
+      resolve(responseBody)
+    })
+  })
+}

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -347,15 +347,6 @@ export const createXMLHttpRequestOverride = (
               this.responseText = originalRequest.responseText
               this.responseXML = originalRequest.responseXML
 
-              const originalSymbols = Object.getOwnPropertySymbols(
-                originalRequest
-              )
-              const propertiesSymbol = originalSymbols[2]
-
-              const originalRequestProperties: XMLHttpRequestProperties =
-                // @ts-ignore
-                originalRequest[propertiesSymbol]
-
               debug(
                 'received original response status:',
                 this.status,
@@ -366,10 +357,21 @@ export const createXMLHttpRequestOverride = (
               this.trigger('loadstart')
               this.trigger('load')
 
+              const responseHeaders = originalRequest.getAllResponseHeaders()
+              debug('original response headers', responseHeaders)
+
+              const normalizedResponseHeaders = headersToObject(
+                stringToHeaders(responseHeaders)
+              )
+              debug(
+                'original response headers (normalized)',
+                normalizedResponseHeaders
+              )
+
               context.emitter.emit('response', req, {
                 status: originalRequest.status,
                 statusText: originalRequest.statusText,
-                headers: originalRequestProperties.responseHeaders,
+                headers: normalizedResponseHeaders,
                 body: originalRequest.response,
               })
             }

--- a/src/interceptors/XMLHttpRequest/index.ts
+++ b/src/interceptors/XMLHttpRequest/index.ts
@@ -13,12 +13,13 @@ const original = {
 /**
  * Intercepts requests issued via `XMLHttpRequest`.
  */
-export const interceptXMLHttpRequest: Interceptor = (middleware) => {
+export const interceptXMLHttpRequest: Interceptor = (middleware, context) => {
   if (original.XMLHttpRequest) {
     debug('patching "XMLHttpRequest" module...')
 
     const XMLHttpRequestOverride = createXMLHttpRequestOverride(
       middleware,
+      context,
       original.XMLHttpRequest
     )
 

--- a/test/events/response.node.test.ts
+++ b/test/events/response.node.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import {
+  RequestInterceptor,
+  InterceptedRequest,
+  MockedResponse,
+} from '../../src'
+import withDefaultInterceptors from '../../src/presets/default'
+import { httpsRequest } from '../helpers'
+import { createServer, httpsAgent, ServerAPI } from '../utils/createServer'
+
+let server: ServerAPI
+let interceptor: RequestInterceptor
+let responses: [InterceptedRequest, Partial<MockedResponse>][] = []
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.post('/account', (req, res) => {
+      return res.status(200).set('X-Response-Custom', 'yes').json(req.body)
+    })
+  })
+
+  interceptor = new RequestInterceptor(withDefaultInterceptors)
+  interceptor.use((req) => {
+    if (['https://mswjs.io/events'].includes(req.url.href)) {
+      return {
+        status: 200,
+        headers: {
+          'X-Response-Custom': 'yes',
+        },
+        body: 'response-text',
+      }
+    }
+  })
+  interceptor.on('response', (req, res) => {
+    responses.push([req, res])
+  })
+})
+
+afterEach(() => {
+  responses = []
+})
+
+afterAll(async () => {
+  interceptor.restore()
+  await server.close()
+})
+
+test('ClientRequest: emits the "response" event upon the mocked response', async () => {
+  await fetch('https://mswjs.io/events')
+
+  expect(responses).toHaveLength(1)
+  const [request, response] = responses[0]
+
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request.url).toBeInstanceOf(URL)
+  expect(request.url.toString()).toBe('https://mswjs.io/events')
+  expect(request).toHaveProperty('body', '')
+
+  expect(response).toHaveProperty('status', 200)
+  expect(response.headers).toHaveProperty('X-Response-Custom', 'yes')
+  expect(response).toHaveProperty('body', 'response-text')
+})
+
+test('ClientRequest: emits the "response" event upon the original response', async () => {
+  await httpsRequest(
+    server.makeHttpsUrl('/account'),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Custom': 'yes',
+      },
+      agent: httpsAgent,
+    },
+    JSON.stringify({ id: 'abc-123' })
+  )
+
+  expect(responses).toHaveLength(1)
+  const [request, response] = responses[0]
+
+  expect(request).toHaveProperty('method', 'POST')
+  expect(request.url).toBeInstanceOf(URL)
+  expect(request.url.toString()).toBe(server.makeHttpsUrl('/account'))
+  expect(request.headers).toHaveProperty('content-type', 'application/json')
+  expect(request.headers).toHaveProperty('x-request-custom', 'yes')
+  expect(request).toHaveProperty('body', `{"id":"abc-123"}`)
+
+  expect(response).toHaveProperty('status', 200)
+  expect(response).toHaveProperty('statusText', 'OK')
+  expect(response.headers).toHaveProperty('x-response-custom', 'yes')
+  expect(response).toHaveProperty('body', 'response-text')
+})

--- a/test/events/response.node.test.ts
+++ b/test/events/response.node.test.ts
@@ -18,7 +18,10 @@ let responses: [InterceptedRequest, Partial<MockedResponse>][] = []
 beforeAll(async () => {
   server = await createServer((app) => {
     app.post('/account', (req, res) => {
-      return res.status(200).set('X-Response-Custom', 'yes').json(req.body)
+      return res
+        .status(200)
+        .set('X-Response-Custom', 'yes')
+        .send('original-response-text')
     })
   })
 
@@ -91,5 +94,5 @@ test('ClientRequest: emits the "response" event upon the original response', asy
   expect(response).toHaveProperty('status', 200)
   expect(response).toHaveProperty('statusText', 'OK')
   expect(response.headers).toHaveProperty('x-response-custom', 'yes')
-  expect(response).toHaveProperty('body', 'response-text')
+  expect(response).toHaveProperty('body', 'original-response-text')
 })

--- a/test/events/response.node.test.ts
+++ b/test/events/response.node.test.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
     app.post('/account', (req, res) => {
       return res
         .status(200)
-        .set('X-Response-Custom', 'yes')
+        .set('x-response-type', 'original')
         .send('original-response-text')
     })
   })
@@ -31,7 +31,7 @@ beforeAll(async () => {
       return {
         status: 200,
         headers: {
-          'X-Response-Custom': 'yes',
+          'x-response-type': 'mocked',
         },
         body: 'response-text',
       }
@@ -63,7 +63,7 @@ test('ClientRequest: emits the "response" event upon the mocked response', async
   expect(request).toHaveProperty('body', '')
 
   expect(response).toHaveProperty('status', 200)
-  expect(response.headers).toHaveProperty('X-Response-Custom', 'yes')
+  expect(response.headers).toHaveProperty('x-response-type', 'mocked')
   expect(response).toHaveProperty('body', 'response-text')
 })
 
@@ -93,6 +93,6 @@ test('ClientRequest: emits the "response" event upon the original response', asy
 
   expect(response).toHaveProperty('status', 200)
   expect(response).toHaveProperty('statusText', 'OK')
-  expect(response.headers).toHaveProperty('x-response-custom', 'yes')
+  expect(response.headers).toHaveProperty('x-response-type', 'original')
   expect(response).toHaveProperty('body', 'original-response-text')
 })

--- a/test/events/response.test.ts
+++ b/test/events/response.test.ts
@@ -20,6 +20,7 @@ beforeAll(async () => {
     app.post('/account', (req, res) => {
       return res
         .status(200)
+        .set('access-control-expose-headers', 'x-response-type')
         .set('x-response-type', 'original')
         .send('original-response-text')
     })

--- a/test/events/response.test.ts
+++ b/test/events/response.test.ts
@@ -1,0 +1,92 @@
+import {
+  InterceptedRequest,
+  MockedResponse,
+  RequestInterceptor,
+} from '../../src'
+import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
+import { createXMLHttpRequest } from '../helpers'
+import { createServer, ServerAPI } from '../utils/createServer'
+
+let server: ServerAPI
+let interceptor: RequestInterceptor
+let responses: [InterceptedRequest, Partial<MockedResponse>][] = []
+
+beforeAll(async () => {
+  // @ts-ignore
+  // Allow XHR requests to the local HTTPS server with a self-signed certificate.
+  window._resourceLoader._strictSSL = false
+
+  server = await createServer((app) => {
+    app.post('/account', (req, res) => {
+      return res
+        .status(200)
+        .set('x-response-type', 'original')
+        .send('original-response-text')
+    })
+  })
+
+  interceptor = new RequestInterceptor([interceptXMLHttpRequest])
+  interceptor.use((req) => {
+    if (['https://mswjs.io/events'].includes(req.url.href)) {
+      return {
+        status: 200,
+        headers: {
+          'x-response-type': 'mocked',
+        },
+        body: 'response-text',
+      }
+    }
+  })
+  interceptor.on('response', (req, res) => {
+    responses.push([req, res])
+  })
+})
+
+afterEach(() => {
+  responses = []
+})
+
+afterAll(async () => {
+  interceptor.restore()
+  await server.close()
+})
+
+test('XMLHttpRequest: emits the "response" event upon the mocked response', async () => {
+  await createXMLHttpRequest((req) => {
+    req.open('GET', 'https://mswjs.io/events')
+    req.setRequestHeader('x-request-custom', 'yes')
+  })
+
+  expect(responses).toHaveLength(1)
+  const [request, response] = responses[0]
+
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request.url.toString()).toBe('https://mswjs.io/events')
+  expect(request.headers).toHaveProperty('x-request-custom', 'yes')
+
+  expect(response).toHaveProperty('status', 200)
+  expect(response).toHaveProperty('statusText', 'OK')
+  expect(response.headers).toHaveProperty('x-response-type', 'mocked')
+  expect(response).toHaveProperty('body', 'response-text')
+})
+
+test('XMLHttpRequest: emits the "response" event upon the original response', async () => {
+  await createXMLHttpRequest((req) => {
+    req.open('POST', server.makeHttpsUrl('/account'))
+    req.setRequestHeader('x-request-custom', 'yes')
+    req.send('request-body')
+  })
+
+  expect(responses).toHaveLength(1)
+  const [request, response] = responses[0]
+
+  expect(request).toHaveProperty('method', 'POST')
+  expect(request.url.toString()).toBe(server.makeHttpsUrl('/account'))
+  expect(request.headers).toHaveProperty('x-request-custom', 'yes')
+  expect(request).toHaveProperty('body', 'request-body')
+
+  expect(response).toHaveProperty('status', 200)
+  expect(response).toHaveProperty('statusText', 'OK')
+  expect(response.headers).toHaveProperty('x-response-type', 'original')
+  expect(response).toHaveProperty('body', 'original-response-text')
+})

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -4,6 +4,7 @@ import nodeFetch, { Response, RequestInfo, RequestInit } from 'node-fetch'
 import { getRequestOptionsByUrl } from '../src/utils/getRequestOptionsByUrl'
 import { InterceptedRequest } from '../src/glossary'
 import { getCleanUrl } from '../src/utils/getCleanUrl'
+import { getIncomingMessageBody } from '../src/interceptors/ClientRequest/utils/getIncomingMessageBody'
 
 interface PromisifiedResponse {
   res: IncomingMessage
@@ -16,7 +17,6 @@ export function httpGet(
   url: string,
   options?: RequestOptions
 ): Promise<PromisifiedResponse> {
-  let resBody = ''
   const parsedUrl = new URL(url)
   const resolvedOptions = Object.assign(
     {},
@@ -25,13 +25,10 @@ export function httpGet(
   )
 
   return new Promise((resolve, reject) => {
-    const req = http.get(resolvedOptions, (res) => {
+    const req = http.get(resolvedOptions, async (res) => {
       res.setEncoding('utf8')
-      res.on('data', (chunk) => (resBody += chunk))
-      res.on('error', reject)
-      res.on('end', () =>
-        resolve({ res, resBody, url, options: resolvedOptions })
-      )
+      const resBody = await getIncomingMessageBody(res)
+      resolve({ res, resBody, url, options: resolvedOptions })
     })
 
     req.on('error', reject)
@@ -42,7 +39,6 @@ export function httpsGet(
   url: string,
   options?: RequestOptions
 ): Promise<PromisifiedResponse> {
-  let resBody = ''
   const parsedUrl = new URL(url)
   const resolvedOptions = Object.assign(
     {},
@@ -51,13 +47,10 @@ export function httpsGet(
   )
 
   return new Promise((resolve, reject) => {
-    const req = https.get(resolvedOptions, (res) => {
+    const req = https.get(resolvedOptions, async (res) => {
       res.setEncoding('utf8')
-      res.on('data', (chunk) => (resBody += chunk))
-      res.on('error', reject)
-      res.on('end', () =>
-        resolve({ res, resBody, url, options: resolvedOptions })
-      )
+      const resBody = await getIncomingMessageBody(res)
+      resolve({ res, resBody, url, options: resolvedOptions })
     })
 
     req.on('error', reject)
@@ -69,7 +62,6 @@ export function httpRequest(
   options?: RequestOptions,
   body?: string
 ): Promise<PromisifiedResponse> {
-  let resBody = ''
   const parsedUrl = new URL(url)
   const resolvedOptions = Object.assign(
     {},
@@ -77,14 +69,11 @@ export function httpRequest(
     options
   )
 
-  return new Promise((resolve, reject) => {
-    const req = http.request(resolvedOptions, (res) => {
+  return new Promise((resolve) => {
+    const req = http.request(resolvedOptions, async (res) => {
       res.setEncoding('utf8')
-      res.on('data', (chunk) => (resBody += chunk))
-      res.on('error', reject)
-      res.on('end', () =>
-        resolve({ res, resBody, url, options: resolvedOptions })
-      )
+      const resBody = await getIncomingMessageBody(res)
+      resolve({ res, resBody, url, options: resolvedOptions })
     })
 
     if (body) {
@@ -100,7 +89,6 @@ export function httpsRequest(
   options?: RequestOptions,
   body?: string
 ): Promise<PromisifiedResponse> {
-  let resBody = ''
   const parsedUrl = new URL(url)
   const resolvedOptions = Object.assign(
     {},
@@ -108,14 +96,11 @@ export function httpsRequest(
     options
   )
 
-  return new Promise((resolve, reject) => {
-    const req = https.request(resolvedOptions, (res) => {
+  return new Promise((resolve) => {
+    const req = https.request(resolvedOptions, async (res) => {
       res.setEncoding('utf8')
-      res.on('data', (chunk) => (resBody += chunk))
-      res.on('error', reject)
-      res.on('end', () =>
-        resolve({ res, resBody, url, options: resolvedOptions })
-      )
+      const resBody = await getIncomingMessageBody(res)
+      resolve({ res, resBody, url, options: resolvedOptions })
     })
 
     if (body) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3659,6 +3659,11 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
+strict-event-emitter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz#fd742c1fb7e3852f0b964ecdae2d7666a6fb7ef8"
+  integrity sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==
+
 string-length@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"


### PR DESCRIPTION
## GitHub

- Closes #25
- Enables https://github.com/mswjs/msw/pull/482

## Changes

It's now possible to listen to any response (original/mocked) using the `on` method of the interceptor:

```js
const interceptor = new RequestInterceptor(...)

interceptor.on('response', (req, res) => {
  req // intercepted request instance
  res // real/mocked response coerced to the `MockedResponse` object shape
})
```

## Roadmap

- [x] Propagate the original `ClientRequest` response body to the `response` event. 
- [x] Find a better way to get access to the original XMLHttpRequest response headers than relying on an internal Symbol.