### PR TITLE
add static copies of readyState values

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -56,6 +56,11 @@ export const createXMLHttpRequestOverride = (
     _events: XMLHttpRequestEvent<XMLHttpRequestEventTargetEventMap>[] = []
 
     /* Request state */
+    public static readonly UNSENT = 0
+    public static readonly OPENED = 1
+    public static readonly HEADERS_RECEIVED = 2
+    public static readonly LOADING = 3
+    public static readonly DONE = 4
     public readonly UNSENT = 0
     public readonly OPENED = 1
     public readonly HEADERS_RECEIVED = 2

--- a/test/compliance/XMLHttpRequest.test.ts
+++ b/test/compliance/XMLHttpRequest.test.ts
@@ -1,0 +1,27 @@
+import { RequestInterceptor } from '../../src'
+import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
+
+let interceptor: RequestInterceptor
+
+beforeAll(() => {
+  interceptor = new RequestInterceptor([interceptXMLHttpRequest])
+})
+
+afterAll(() => {
+  interceptor.restore()
+})
+
+test('exposes ready state enums both as static and public properties', () => {
+  expect(XMLHttpRequest.UNSENT).toBe(0)
+  expect(XMLHttpRequest.OPENED).toBe(1)
+  expect(XMLHttpRequest.HEADERS_RECEIVED).toBe(2)
+  expect(XMLHttpRequest.LOADING).toBe(3)
+  expect(XMLHttpRequest.DONE).toBe(4)
+
+  const xhr = new XMLHttpRequest()
+  expect(xhr.UNSENT).toBe(0)
+  expect(xhr.OPENED).toBe(1)
+  expect(xhr.HEADERS_RECEIVED).toBe(2)
+  expect(xhr.LOADING).toBe(3)
+  expect(xhr.DONE).toBe(4)
+})


### PR DESCRIPTION
TypeScript's `interface XMLHttpRequest` in lib.dom.d.ts requires these properties to exist as static and instance properties. I've added the static properties here, but I'm unsure how to enforce them against the type.

https://github.com/microsoft/TypeScript/blob/2428ade1a91248e847f3e1561e31a9426650efee/lib/lib.dom.d.ts#L18806-L18810

https://github.com/microsoft/TypeScript/blob/2428ade1a91248e847f3e1561e31a9426650efee/lib/lib.dom.d.ts#L18817-L18825

Fixes #78 