### PR TITLE
fix: propagate headers when making original XMLHttpRequest

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -380,6 +380,7 @@ export const createXMLHttpRequestOverride = (
             // to the original XHR instance.
             this.propagateCallbacks(originalRequest)
             this.propagateListeners(originalRequest)
+            this.propagateHeaders(originalRequest, requestHeaders)
 
             if (this.async) {
               originalRequest.timeout = this.timeout
@@ -530,6 +531,18 @@ export const createXMLHttpRequestOverride = (
     propagateListeners(req: XMLHttpRequest) {
       this._events.forEach(({ name, listener }) => {
         req.addEventListener(name, listener)
+      })
+    }
+
+    propagateHeaders(
+      req: XMLHttpRequest,
+      headers: Record<string, string | string[]>
+    ) {
+      Object.entries(headers).forEach(([key, value]) => {
+        req.setRequestHeader(
+          key,
+          Array.isArray(value) ? value.join(',') : value
+        )
       })
     }
   }

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -358,6 +358,9 @@ export const createXMLHttpRequestOverride = (
               this.trigger('load')
 
               const responseHeaders = originalRequest.getAllResponseHeaders()
+              this.responseHeaders = flattenHeadersObject(
+                headersToObject(stringToHeaders(responseHeaders))
+              )
               debug('original response headers', responseHeaders)
 
               const normalizedResponseHeaders = headersToObject(
@@ -538,11 +541,9 @@ export const createXMLHttpRequestOverride = (
       req: XMLHttpRequest,
       headers: Record<string, string | string[]>
     ) {
-      Object.entries(headers).forEach(([key, value]) => {
-        req.setRequestHeader(
-          key,
-          Array.isArray(value) ? value.join(',') : value
-        )
+      const flatHeaders = flattenHeadersObject(headers)
+      Object.entries(flatHeaders).forEach(([key, value]) => {
+        req.setRequestHeader(key, value)
       })
     }
   }

--- a/test/regressions/xhr-propagate-headers.test.ts
+++ b/test/regressions/xhr-propagate-headers.test.ts
@@ -31,16 +31,14 @@ afterAll(() => {
 })
 
 test('forward the request headers to the server', async () => {
-  await createXMLHttpRequest((req) => {
+  const req = await createXMLHttpRequest((req) => {
     req.open('GET', server.makeHttpUrl('/account'))
     req.setRequestHeader('x-client-header', 'yes')
     req.setRequestHeader('x-multi-values', 'value1, value2')
-    req.send()
-    req.addEventListener('loadend', function () {
-      const headers = this.getAllResponseHeaders()
-      expect(headers).toContain('x-response-type: original')
-      expect(headers).toContain('x-client-header: yes')
-      expect(headers).toContain('x-multi-values: value1, value2')
-    })
   })
+
+  const headers = req.getAllResponseHeaders()
+  expect(headers).toContain('x-response-type: original')
+  expect(headers).toContain('x-client-header: yes')
+  expect(headers).toContain('x-multi-values: value1, value2')
 })

--- a/test/regressions/xhr-propagate-headers.test.ts
+++ b/test/regressions/xhr-propagate-headers.test.ts
@@ -1,0 +1,46 @@
+import { RequestInterceptor } from '../../src'
+import { createXMLHttpRequest } from '../helpers'
+import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
+import { createServer, ServerAPI } from '../utils/createServer'
+
+let server: ServerAPI
+let interceptor: RequestInterceptor
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.get('/account', (req, res) => {
+      return res
+        .status(200)
+        .set(
+          'access-control-expose-headers',
+          'x-response-type, x-client-header, x-multi-values'
+        )
+        .set('x-response-type', 'original')
+        .set('x-client-header', req.get('x-client-header'))
+        .set('x-multi-values', req.get('x-multi-values'))
+        .send(null)
+    })
+  })
+
+  interceptor = new RequestInterceptor([interceptXMLHttpRequest])
+})
+
+afterAll(() => {
+  server.close()
+  interceptor.restore()
+})
+
+test('forward the request headers to the server', async () => {
+  await createXMLHttpRequest((req) => {
+    req.open('GET', server.makeHttpUrl('/account'))
+    req.setRequestHeader('x-client-header', 'yes')
+    req.setRequestHeader('x-multi-values', 'value1, value2')
+    req.send()
+    req.addEventListener('loadend', function () {
+      const headers = this.getAllResponseHeaders()
+      expect(headers).toContain('x-response-type: original')
+      expect(headers).toContain('x-client-header: yes')
+      expect(headers).toContain('x-multi-values: value1, value2')
+    })
+  })
+})

--- a/test/regressions/xhr-propagate-headers.test.ts
+++ b/test/regressions/xhr-propagate-headers.test.ts
@@ -34,11 +34,11 @@ test('forward the request headers to the server', async () => {
   const req = await createXMLHttpRequest((req) => {
     req.open('GET', server.makeHttpUrl('/account'))
     req.setRequestHeader('x-client-header', 'yes')
-    req.setRequestHeader('x-multi-values', 'value1, value2')
+    req.setRequestHeader('x-multi-values', 'value1; value2')
   })
 
   const headers = req.getAllResponseHeaders()
   expect(headers).toContain('x-response-type: original')
   expect(headers).toContain('x-client-header: yes')
-  expect(headers).toContain('x-multi-values: value1, value2')
+  expect(headers).toContain('x-multi-values: value1; value2')
 })


### PR DESCRIPTION
## Changes

- When the request is not mocked, the original request is made. This PR will fix an issue where client headers were not forwarded to the server
