### PR TITLE
Events: Ensures full "MockedResponse" instance in the callback

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -41,9 +41,9 @@ export interface MockedResponse {
   status: number
   statusText: string
   headers: Record<string, string | string[]>
-  body: string
+  body: string | undefined
 }
 
 export interface RequestInterceptorEventsMap {
-  response: (req: InterceptedRequest, res: Partial<MockedResponse>) => void
+  response: (req: InterceptedRequest, res: MockedResponse) => void
 }

--- a/src/interceptors/ClientRequest/ClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/ClientRequestOverride.ts
@@ -238,7 +238,12 @@ export function createClientRequestOverrideClass(
         response.push(null)
         response.complete = true
 
-        context.emitter.emit('response', formattedRequest, mockedResponse)
+        context.emitter.emit('response', formattedRequest, {
+          status: mockedResponse.status || 200,
+          statusText: mockedResponse.statusText || 'OK',
+          headers: mockedResponse.headers || {},
+          body: mockedResponse.body,
+        })
 
         return this
       }
@@ -293,8 +298,8 @@ export function createClientRequestOverrideClass(
 
       req.on('response', async (response) => {
         context.emitter.emit('response', formattedRequest, {
-          status: response.statusCode,
-          statusText: response.statusMessage,
+          status: response.statusCode || 200,
+          statusText: response.statusMessage || 'OK',
           headers: response.headers as MockedResponse['headers'],
           body: await getIncomingMessageBody(response),
         })

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -310,7 +310,7 @@ export const createXMLHttpRequestOverride = (
             context.emitter.emit('response', req, {
               status: this.status,
               statusText: this.statusText,
-              headers: mockedResponse.headers,
+              headers: mockedResponse.headers || {},
               body: mockedResponse.body,
             })
           } else {


### PR DESCRIPTION
## GitHub

- Fixes #82

## Changes

- The `response` event now returns a full `MockedResponse` object, not partial. 
- `MockedResponse.body` is now properly annotated as `string | undefined` (the lack of body is represented as `undefined`).
- `200` is used is a fallback `IncomingMessage.statusCode` and `OK` is used as a fallback for `IncomingMessage.statusText`, however, those fallbacks are only to satisfy TypeScript, as both properties are _set and present_ once the response headers are written (it's possible to access them before the headers are written, and _then_ they are undefined). 