### PR TITLE
XMLHttpRequest `getResponseHeader` case sensitivity

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -422,13 +422,7 @@ export const createXMLHttpRequestOverride = (
       const headerValue = Object.entries(this.responseHeaders).reduce<
         string | null
       >((_, [headerName, headerValue]) => {
-        // Ignore header name casing while still allowing to set response headers
-        // with an arbitrary casing (no normalization).
-        if ([headerName, headerName.toLowerCase()].includes(name)) {
-          return headerValue
-        }
-
-        return null
+        return (headerName.toLowerCase() === name.toLowerCase()) ? headerValue : null
       }, null)
 
       debug('resolved response header', name, headerValue, this.responseHeaders)

--- a/test/regressions/xhr-response-header-case-sensitivity.test.ts
+++ b/test/regressions/xhr-response-header-case-sensitivity.test.ts
@@ -1,0 +1,40 @@
+import { ServerApi, createServer } from '@open-draft/test-server'
+import { RequestInterceptor } from '../../src'
+import { createXMLHttpRequest } from '../helpers'
+import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
+
+let server: ServerApi
+let interceptor: RequestInterceptor
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.get('/account', (req, res) => {
+      return res
+        .status(200)
+        .set(
+          'access-control-expose-headers',
+          'x-test-header'
+        )
+        .set('x-test-header', req.get('x-test-header'))
+        .send(null)
+    })
+  })
+
+  interceptor = new RequestInterceptor([interceptXMLHttpRequest])
+})
+
+afterAll(async () => {
+  interceptor.restore()
+  await server.close()
+})
+
+test('getResponseHeader is case insensitive', async () => {
+  const req = await createXMLHttpRequest((req) => {
+    req.open('GET', server.http.makeUrl('/account'))
+    req.setRequestHeader('x-test-header', 'test-value')
+  })
+
+  expect(req.getResponseHeader('x-test-header')).toEqual('test-value')
+  expect(req.getResponseHeader('X-Test-Header')).toEqual('test-value')
+  expect(req.getResponseHeader('X-TEST-HEADER')).toEqual('test-value')
+})


### PR DESCRIPTION
I came across a problem when using MSW in testing: the component under test has a dependency that makes API calls (authentication) and inspects the "Content-Type" response header (note the casing), but the value of this header was always null. I traced this to the XMLHttpRequestOverride's `getResponseHeader` function which evaluated "Content-Type" (the passed in header name) against "content-type" (the actual header name in the response), thereby failing and returning null.

This PR updates the XHR `getResponseHeader` function to normalise the passed in header name and the response headers to lowercase when evaluating equality. This looks to be similar behaviour to [jsdom's implementation](https://github.com/jsdom/jsdom/blob/5279cfda5fe4d52f04b2eb6a801c98d81f9b55da/lib/jsdom/living/xhr/xhr-utils.js#L32) and aligns with HTTP spec.