### PR TITLE
ClientRequest: Infers protocol from the request module (defaultProtocol) if not provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
     "jest": "^25.4.0",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.2",
+    "superagent": "^6.1.0",
     "supertest": "^4.0.2",
     "ts-jest": "^25.4.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.2.3"
   },
   "dependencies": {
     "@open-draft/until": "^1.0.3",

--- a/src/interceptors/ClientRequest/createClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/createClientRequestOverride.ts
@@ -23,6 +23,7 @@ import { IsomoprhicRequest, Observer, Resolver } from '../../createInterceptor'
 const createDebug = require('debug')
 
 interface CreateClientRequestOverrideOptions {
+  defaultProtocol: string
   pureClientRequest: typeof http.ClientRequest
   pureMethod: typeof http.get | typeof http.request
   observer: Observer
@@ -32,13 +33,22 @@ interface CreateClientRequestOverrideOptions {
 export function createClientRequestOverride(
   options: CreateClientRequestOverrideOptions
 ) {
-  const { pureClientRequest, pureMethod, observer, resolver } = options
+  const {
+    defaultProtocol,
+    pureClientRequest,
+    pureMethod,
+    observer,
+    resolver,
+  } = options
 
   function ClientRequestOverride(
     this: http.ClientRequest,
     ...args: Parameters<typeof http.request>
   ) {
-    const [url, options, callback] = normalizeHttpRequestParams(...args)
+    const [url, options, callback] = normalizeHttpRequestParams(
+      defaultProtocol,
+      ...args
+    )
     const usesHttps = url.protocol === 'https:'
     let requestBodyBuffer: Buffer[] = []
 

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -7,7 +7,7 @@ const debug = require('debug')('http override')
 
 type Protocol = 'http' | 'https'
 type PureModules = Map<
-  'http' | 'https',
+  Protocol,
   {
     module: typeof http | typeof https
     get: typeof http.get
@@ -20,7 +20,7 @@ type PureModules = Map<
 let pureClientRequest: typeof http.ClientRequest
 
 function handleClientRequest(
-  protocol: Protocol,
+  protocol: string,
   pureMethod: typeof http.get | typeof http.request,
   args: any[],
   observer: Observer,
@@ -33,6 +33,7 @@ function handleClientRequest(
   }
 
   const ClientRequestOverride = createClientRequestOverride({
+    defaultProtocol: `${protocol}:`,
     pureClientRequest,
     pureMethod,
     observer,
@@ -56,7 +57,7 @@ function handleClientRequest(
  */
 export const interceptClientRequest: Interceptor = (observer, resolver) => {
   const pureModules: PureModules = new Map()
-  const modules: Array<Protocol> = ['http', 'https']
+  const modules: Protocol[] = ['http', 'https']
 
   modules.forEach((protocol) => {
     const requestModule = protocol === 'https' ? https : http

--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.test.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.test.ts
@@ -1,13 +1,13 @@
-import { parse } from 'url';
-import { getUrlByRequestOptions } from '../../../utils/getUrlByRequestOptions';
+import { parse } from 'url'
+import { getUrlByRequestOptions } from '../../../utils/getUrlByRequestOptions'
 import { normalizeHttpRequestParams } from './normalizeHttpRequestParams'
 
 test('handles [string, callback] input', () => {
-  const [
-    url,
-    options,
-    callback,
-  ] = normalizeHttpRequestParams('https://mswjs.io/resource', function cb() {})
+  const [url, options, callback] = normalizeHttpRequestParams(
+    'https:',
+    'https://mswjs.io/resource',
+    function cb() {}
+  )
 
   // URL string must be converted to a URL instance
   expect(url.toJSON()).toEqual(new URL('https://mswjs.io/resource').toJSON())
@@ -28,11 +28,8 @@ test('handles [string, RequestOptions, callback] input', () => {
       'Content-Type': 'text/plain',
     },
   }
-  const [
-    url,
-    options,
-    callback,
-  ] = normalizeHttpRequestParams(
+  const [url, options, callback] = normalizeHttpRequestParams(
+    'https:',
     'https://mswjs.io/resource',
     initialOptions,
     function cb() {}
@@ -50,6 +47,7 @@ test('handles [string, RequestOptions, callback] input', () => {
 
 test('handles [URL, callback] input', () => {
   const [url, options, callback] = normalizeHttpRequestParams(
+    'https:',
     new URL('https://mswjs.io/resource'),
     function cb() {}
   )
@@ -69,12 +67,17 @@ test('handles [URL, callback] input', () => {
 
 test('handles [Absolute Legacy URL, callback] input', () => {
   const [url, options, callback] = normalizeHttpRequestParams(
+    'https:',
     parse('https://cherry:durian@mswjs.io:12345/resource?apple=banana'),
     function cb() {}
   )
 
   // URL must be preserved
-  expect(url.toJSON()).toEqual(new URL('https://cherry:durian@mswjs.io:12345/resource?apple=banana').toJSON())
+  expect(url.toJSON()).toEqual(
+    new URL(
+      'https://cherry:durian@mswjs.io:12345/resource?apple=banana'
+    ).toJSON()
+  )
 
   // Request options must be derived from the URL instance
   expect(options).toHaveProperty('method', 'GET')
@@ -90,13 +93,16 @@ test('handles [Absolute Legacy URL, callback] input', () => {
 
 test('handles [Relative Legacy URL, RequestOptions without path set, callback] input', () => {
   const [url, options, callback] = normalizeHttpRequestParams(
+    'http:',
     parse('/resource?apple=banana'),
-    {host: 'mswjs.io'},
+    { host: 'mswjs.io' },
     function cb() {}
   )
 
   // Correct WHATWG URL generated
-  expect(url.toJSON()).toEqual(new URL('http://mswjs.io/resource?apple=banana').toJSON())
+  expect(url.toJSON()).toEqual(
+    new URL('http://mswjs.io/resource?apple=banana').toJSON()
+  )
 
   // No path in request options, so legacy url path is copied-in
   expect(options).toHaveProperty('protocol', 'http:')
@@ -109,13 +115,16 @@ test('handles [Relative Legacy URL, RequestOptions without path set, callback] i
 
 test('handles [Relative Legacy URL, RequestOptions with path set, callback] input', () => {
   const [url, options, callback] = normalizeHttpRequestParams(
+    'http:',
     parse('/resource?apple=banana'),
-    {host: 'mswjs.io', path: '/other?cherry=durian'},
+    { host: 'mswjs.io', path: '/other?cherry=durian' },
     function cb() {}
   )
 
   // Correct WHATWG URL generated
-  expect(url.toJSON()).toEqual(new URL('http://mswjs.io/other?cherry=durian').toJSON())
+  expect(url.toJSON()).toEqual(
+    new URL('http://mswjs.io/other?cherry=durian').toJSON()
+  )
 
   // Path in request options, so that path is preferred
   expect(options).toHaveProperty('protocol', 'http:')
@@ -128,12 +137,17 @@ test('handles [Relative Legacy URL, RequestOptions with path set, callback] inpu
 
 test('handles [Relative Legacy URL, callback] input', () => {
   const [url, options, callback] = normalizeHttpRequestParams(
+    'http:',
     parse('/resource?apple=banana'),
     function cb() {}
   )
 
   // Correct WHATWG URL generated
-  expect(url.toJSON()).toMatch(getUrlByRequestOptions({path: '/resource?apple=banana'}).toJSON())
+  expect(url.toJSON()).toMatch(
+    getUrlByRequestOptions({
+      path: '/resource?apple=banana',
+    }).toJSON()
+  )
 
   // Check path is in options
   expect(options).toHaveProperty('protocol', 'http:')
@@ -145,11 +159,16 @@ test('handles [Relative Legacy URL, callback] input', () => {
 
 test('handles [Relative Legacy URL] input', () => {
   const [url, options, callback] = normalizeHttpRequestParams(
+    'http:',
     parse('/resource?apple=banana')
   )
 
   // Correct WHATWG URL generated
-  expect(url.toJSON()).toMatch(getUrlByRequestOptions({path: '/resource?apple=banana'}).toJSON())
+  expect(url.toJSON()).toMatch(
+    getUrlByRequestOptions({
+      path: '/resource?apple=banana',
+    }).toJSON()
+  )
 
   // Check path is in options
   expect(options).toHaveProperty('protocol', 'http:')
@@ -161,6 +180,7 @@ test('handles [Relative Legacy URL] input', () => {
 
 test('handles [URL, RequestOptions, callback] input', () => {
   const [url, options, callback] = normalizeHttpRequestParams(
+    'https:',
     new URL('https://mswjs.io/resource'),
     {
       headers: {
@@ -176,6 +196,7 @@ test('handles [URL, RequestOptions, callback] input', () => {
   // Options must be preserved
   expect(options).toEqual({
     protocol: 'https:',
+    method: 'GET',
     headers: {
       'Content-Type': 'text/plain',
     },
@@ -196,6 +217,7 @@ test('handles [RequestOptions, callback] input', () => {
     },
   }
   const [url, options, callback] = normalizeHttpRequestParams(
+    'https:',
     initialOptions,
     function cb() {}
   )
@@ -206,15 +228,20 @@ test('handles [RequestOptions, callback] input', () => {
   // Request options must be preserved
   expect(options).toEqual(initialOptions)
 
+  expect(options).toHaveProperty('protocol', 'https:')
+
   // Callback must be preserved
   expect(callback).toHaveProperty('name', 'cb')
 })
 
 test('handles [Empty RequestOptions, callback] input', () => {
-  const [_, __, callback] = normalizeHttpRequestParams(
+  const [_, options, callback] = normalizeHttpRequestParams(
+    'https:',
     {},
     function cb() {}
   )
+
+  expect(options).toHaveProperty('protocol', 'https:')
 
   // Callback must be preserved
   expect(callback).toHaveProperty('name', 'cb')
@@ -237,17 +264,21 @@ test('handles [PartialRequestOptions, callback] input', () => {
     agent: false,
   }
   const [url, options, callback] = normalizeHttpRequestParams(
+    'https:',
     initialOptions,
     function cb() {}
   )
 
   // URL must be derived from request options
   expect(url.toJSON()).toEqual(
-    new URL('http://127.0.0.1:50176/resource').toJSON()
+    new URL('https://127.0.0.1:50176/resource').toJSON()
   )
 
   // Request options must be preserved
   expect(options).toEqual(initialOptions)
+
+  // Options protocol must be inferred from the request issuing module.
+  expect(options).toHaveProperty('protocol', 'https:')
 
   // Callback must be preserved
   expect(callback).toHaveProperty('name', 'cb')

--- a/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeHttpRequestParams.ts
@@ -36,6 +36,7 @@ function resolveCallback(
  * so it always has a `URL` and `RequestOptions`.
  */
 export function normalizeHttpRequestParams(
+  defaultProtocol: string,
   ...args: HttpRequestArgs
 ): [URL, RequestOptions & RequestSelf, HttpRequestCallback?] {
   let url: URL
@@ -43,6 +44,7 @@ export function normalizeHttpRequestParams(
   let callback: HttpRequestCallback | undefined
 
   debug('arguments', args)
+  debug('default protocol', defaultProtocol)
 
   // Convert a url string into a URL instance
   // and derive request options from it.
@@ -83,10 +85,12 @@ export function normalizeHttpRequestParams(
 
       return isObject(args[1])
         ? normalizeHttpRequestParams(
+            defaultProtocol,
             { path: legacyUrl.path, ...args[1] },
             args[2]
           )
         : normalizeHttpRequestParams(
+            defaultProtocol,
             { path: legacyUrl.path },
             args[1] as HttpRequestCallback
           )
@@ -98,16 +102,26 @@ export function normalizeHttpRequestParams(
     const resolvedUrl = new URL(legacyUrl.href)
 
     return args[1] === undefined
-      ? normalizeHttpRequestParams(resolvedUrl)
+      ? normalizeHttpRequestParams(defaultProtocol, resolvedUrl)
       : typeof args[1] === 'function'
-      ? normalizeHttpRequestParams(resolvedUrl, args[1])
-      : normalizeHttpRequestParams(resolvedUrl, args[1], args[2])
+      ? normalizeHttpRequestParams(defaultProtocol, resolvedUrl, args[1])
+      : normalizeHttpRequestParams(
+          defaultProtocol,
+          resolvedUrl,
+          args[1],
+          args[2]
+        )
   }
   // Handle a given RequestOptions object as-is
   // and derive the URL instance from it.
   else if (isObject(args[0])) {
     options = args[0]
     debug('given request options:', options)
+
+    // When handling a `RequestOptions` object without an explicit "protocol",
+    // infer the protocol from the request issuing module (http/https).
+    options.protocol = options.protocol || defaultProtocol
+    debug('normalized request options:', options)
 
     url = getUrlByRequestOptions(options)
     debug('created a URL:', url)
@@ -124,6 +138,7 @@ export function normalizeHttpRequestParams(
   // @see https://github.com/nodejs/node/blob/d84f1312915fe45fe0febe888db692c74894c382/lib/_http_client.js#L142-L145
   // This prevents `Protocol "http:" not supported. Expected "https:"` exception for `https.request` calls.
   options.protocol = options.protocol || url.protocol
+  options.method = options.method || 'GET'
 
   debug('resolved URL:', url)
   debug('resolved options:', options)

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -33,7 +33,6 @@ function getProtocolByRequestOptions(
   }
 
   const port = getPortByRequestOptions(options)
-
   const isSecureRequest = options.cert || port === SSL_PORT
 
   return isSecureRequest ? 'https:' : options.uri?.protocol || DEFAULT_PROTOCOL

--- a/test/intercept/http/http.get.test.ts
+++ b/test/intercept/http/http.get.test.ts
@@ -1,11 +1,13 @@
 /**
  * @jest-environment node
  */
+import * as http from 'http'
 import { ServerApi, createServer } from '@open-draft/test-server'
 import { createInterceptor } from '../../../src'
 import { IsomoprhicRequest } from '../../../src/createInterceptor'
 import { interceptClientRequest } from '../../../src/interceptors/ClientRequest'
 import { httpGet, prepare } from '../../helpers'
+import { getIncomingMessageBody } from '../../../src/interceptors/ClientRequest/utils/getIncomingMessageBody'
 
 let pool: IsomoprhicRequest[] = []
 let server: ServerApi
@@ -52,4 +54,24 @@ test('intercepts an http.get request', async () => {
   expect(request).toHaveProperty('method', 'GET')
   expect(request?.url.searchParams.get('id')).toEqual('123')
   expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an http.get requets given RequestOptions without a protocol', (done) => {
+  // Create a request with `RequetOptions` but without an explicit "protocol".
+  // Since request is done via `http.get`, the "http:" protocol must be inferred.
+  const request = http.get(
+    {
+      host: server.http.getAddress().host,
+      port: server.http.getAddress().port,
+      path: '/user',
+    },
+    async (response) => {
+      const responseBody = await getIncomingMessageBody(response)
+      expect(responseBody).toBe('user-body')
+
+      done()
+    }
+  )
+
+  request.end()
 })

--- a/test/intercept/https/https.get.test.ts
+++ b/test/intercept/https/https.get.test.ts
@@ -1,11 +1,13 @@
 /**
  * @jest-environment node
  */
+import * as https from 'https'
 import { ServerApi, createServer, httpsAgent } from '@open-draft/test-server'
 import { createInterceptor } from '../../../src'
 import { IsomoprhicRequest } from '../../../src/createInterceptor'
 import { interceptClientRequest } from '../../../src/interceptors/ClientRequest'
 import { prepare, httpsGet } from '../../helpers'
+import { getIncomingMessageBody } from '../../../src/interceptors/ClientRequest/utils/getIncomingMessageBody'
 
 let pool: IsomoprhicRequest[] = []
 let server: ServerApi
@@ -53,4 +55,26 @@ test('intercepts an HTTPS GET request', async () => {
   expect(request).toHaveProperty('method', 'GET')
   expect(request?.url.searchParams.get('id')).toEqual('123')
   expect(request?.headers).toHaveProperty('x-custom-header', 'yes')
+})
+
+test('intercepts an https.get request given RequestOptions without a protocol', async (done) => {
+  // Pass a RequestOptions object without an explicit `protocol`.
+  // The request is made via `https` so the `https:` protocol must be inferred.
+  const request = https.get(
+    {
+      host: server.https.getAddress().host,
+      port: server.https.getAddress().port,
+      path: '/user',
+      // Suppress the "certificate has expired" error.
+      rejectUnauthorized: false,
+    },
+    async (response) => {
+      const responseBody = await getIncomingMessageBody(response)
+      expect(responseBody).toBe('user-body')
+
+      done()
+    }
+  )
+
+  request.end()
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,7 +1177,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-component-emitter@^1.2.0, component-emitter@^1.2.1:
+component-emitter@^1.2.0, component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -1216,7 +1216,7 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
-cookiejar@^2.1.0:
+cookiejar@^2.1.0, cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
@@ -1632,6 +1632,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fb-watchman@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
@@ -1719,7 +1724,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formidable@^1.2.0:
+formidable@^1.2.0, formidable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
   integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
@@ -1959,7 +1964,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2715,6 +2720,13 @@ lolex@^5.0.0:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -2809,6 +2821,11 @@ mime@1.6.0, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@^2.4.6:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
+  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -3209,6 +3226,11 @@ qs@^6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
+qs@^6.9.4:
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -3265,6 +3287,15 @@ readable-stream@^2.3.5:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 realpath-native@^2.0.0:
   version "2.0.0"
@@ -3397,7 +3428,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3445,6 +3476,13 @@ semver@6.x, semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -3706,6 +3744,13 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -3757,6 +3802,23 @@ superagent@^3.8.3:
     mime "^1.4.1"
     qs "^6.5.1"
     readable-stream "^2.3.5"
+
+superagent@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
+  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
+    formidable "^1.2.2"
+    methods "^1.1.2"
+    mime "^2.4.6"
+    qs "^6.9.4"
+    readable-stream "^3.6.0"
+    semver "^7.3.2"
 
 supertest@^4.0.2:
   version "4.0.2"
@@ -3956,10 +4018,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.8.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -4001,7 +4063,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -4163,6 +4225,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@18.x, yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
## GitHub

- Fixes https://github.com/mswjs/msw/issues/632
- Fixes #67 
- Closes #66

## Changes

- `normalizeHttpRequestParams` function now accepts the `defaultProtocol: string` argument that represents the default protocol associated with the request module (`http`/`https`). 
- **Only if the `protocol` isn't otherwise provided** (i.e. in `options.protocol`, or `URL.protocol`), request params normalization infers the `defaultProtocol`.