### PR TITLE
fix: set readyState to 4 (DONE) on bypassed response

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -342,6 +342,7 @@ export const createXMLHttpRequestOverride = (
               this.response = originalRequest.response
               this.responseText = originalRequest.responseText
               this.responseXML = originalRequest.responseXML
+              this.readyState = this.DONE
 
               debug(
                 'received original response status:',

--- a/test/response/axios.test.ts
+++ b/test/response/axios.test.ts
@@ -1,6 +1,9 @@
 import axios from 'axios'
+import { ServerApi, createServer } from '@open-draft/test-server'
 import { createInterceptor } from '../../src'
 import nodeInterceptors from '../../src/presets/node'
+
+let server: ServerApi
 
 const interceptor = createInterceptor({
   modules: nodeInterceptors,
@@ -20,12 +23,27 @@ const interceptor = createInterceptor({
   },
 })
 
-beforeAll(() => {
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.get('/books', (req, res) => {
+      res.status(200).json([
+        {
+          title: 'The Lord of the Rings',
+          author: 'J. R. R. Tolkien',
+        },
+        {
+          title: 'The Hobbit',
+          author: 'J. R. R. Tolkien',
+        },
+      ])
+    })
+  })
   interceptor.apply()
 })
 
-afterAll(() => {
+afterAll(async () => {
   interceptor.restore()
+  await server.close()
 })
 
 test('responds with a mocked response to an "axios()" request', async () => {
@@ -50,4 +68,20 @@ test('responds with a mocked response to an "axios.post()" request', async () =>
   expect(res.status).toEqual(200)
   expect(res.headers).toHaveProperty('x-header', 'yes')
   expect(res.data).toEqual({ mocked: true })
+})
+
+test('bypass the interceptor and return the original response', async () => {
+  const res = await axios.get(server.http.makeUrl('/books'))
+
+  expect(res.status).toEqual(200)
+  expect(res.data).toEqual([
+    {
+      title: 'The Lord of the Rings',
+      author: 'J. R. R. Tolkien',
+    },
+    {
+      title: 'The Hobbit',
+      author: 'J. R. R. Tolkien',
+    },
+  ])
 })


### PR DESCRIPTION
As for the mocked request also bypass request should have the readyState set to 4 (DONE) when a response is received

Fixes https://github.com/mswjs/msw/issues/636