### PR TITLE
XMLHttpRequest: Removes an extra space in ".getAllResponseHeaders"

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -446,7 +446,7 @@ export const createXMLHttpRequestOverride = (
       }
 
       return Object.entries(this.responseHeaders)
-        .map(([name, value]) => `${name}: ${value} \r\n`)
+        .map(([name, value]) => `${name}: ${value}\r\n`)
         .join('')
     }
 

--- a/test/compliance/XMLHttpRequest.test.ts
+++ b/test/compliance/XMLHttpRequest.test.ts
@@ -1,9 +1,17 @@
 import { createInterceptor } from '../../src'
 import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
+import { createXMLHttpRequest } from '../helpers'
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver() {},
+  resolver() {
+    return {
+      headers: {
+        'e-tag': '123',
+        'x-powered-by': 'msw',
+      },
+    }
+  },
 })
 
 beforeAll(() => {
@@ -27,4 +35,13 @@ test('exposes ready state enums both as static and public properties', () => {
   expect(xhr.HEADERS_RECEIVED).toBe(2)
   expect(xhr.LOADING).toBe(3)
   expect(xhr.DONE).toBe(4)
+})
+
+test('retrieves the response headers when called ".getAllResponseHeaders()"', async () => {
+  const request = await createXMLHttpRequest((req) => {
+    req.open('GET', '/')
+  })
+
+  const responseHeaders = request.getAllResponseHeaders()
+  expect(responseHeaders).toEqual('e-tag: 123\r\nx-powered-by: msw\r\n')
 })


### PR DESCRIPTION
## GitHub

- Fixes https://github.com/mswjs/headers-utils/issues/9

## Changes

- Removes an extra space in the headers string when calling `XMLHttpRequest.getAllResponseHeaders()` method.
- Adds a compliance test for `.getAllResponseHeaders()` method.