### PR TITLE
Supports XMLHttpRequest interception in a browser

### DIFF
--- a/src/interceptors/XMLHttpRequest/utils/bufferFrom.test.ts
+++ b/src/interceptors/XMLHttpRequest/utils/bufferFrom.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+import { bufferFrom } from './bufferFrom'
+
+test('returns the same Uint8Array instance as Buffer.from', () => {
+  const init = 'hello world'
+  const buffer = bufferFrom(init)
+  const rawBuffer = Buffer.from(init)
+  expect(Buffer.compare(buffer, rawBuffer)).toBe(0)
+})

--- a/src/interceptors/XMLHttpRequest/utils/bufferFrom.ts
+++ b/src/interceptors/XMLHttpRequest/utils/bufferFrom.ts
@@ -1,0 +1,16 @@
+/**
+ * Convert a given string into a `Uint8Array`.
+ * We don't use `TextEncoder` because it's unavailable in some environments.
+ */
+export function bufferFrom(init: string): Uint8Array {
+  const encodedString = encodeURIComponent(init)
+  const binaryString = encodedString.replace(/%([0-9A-F]{2})/g, (_, char) => {
+    return String.fromCharCode(('0x' + char) as any)
+  })
+  const buffer = new Uint8Array(binaryString.length)
+  Array.prototype.forEach.call(binaryString, (char, index) => {
+    buffer[index] = char.charCodeAt(0)
+  })
+
+  return buffer
+}

--- a/src/interceptors/XMLHttpRequest/utils/createEvent.test.ts
+++ b/src/interceptors/XMLHttpRequest/utils/createEvent.test.ts
@@ -1,0 +1,35 @@
+import { createEvent } from './createEvent'
+import { EventPolyfill } from '../polyfills/EventPolyfill'
+
+interface XMLHttpRequestFlags {
+  method: string
+  uri: string
+}
+
+const request = new XMLHttpRequest()
+request.open('POST', '/user')
+
+test('returns an EventPolyfill instance with the given target set', () => {
+  const event = createEvent(request, 'my-event')
+  const target = event.target as XMLHttpRequest
+
+  const [, flagSymbol] = Object.getOwnPropertySymbols(request)
+  // @ts-ignore
+  const flags = target[flagSymbol] as XMLHttpRequestFlags
+
+  expect(event).toBeInstanceOf(EventPolyfill)
+  expect(target).toBeInstanceOf(XMLHttpRequest)
+  expect(flags.method).toBe('POST')
+  expect(flags.uri).toBe(new URL('/user', location.href).toString())
+})
+
+test('returns the ProgressEvent instance', () => {
+  const event = createEvent(request, 'load', {
+    loaded: 100,
+    total: 500,
+  })
+
+  expect(event).toBeInstanceOf(ProgressEvent)
+  expect(event.loaded).toBe(100)
+  expect(event.total).toBe(500)
+})

--- a/src/interceptors/XMLHttpRequest/utils/createEvent.ts
+++ b/src/interceptors/XMLHttpRequest/utils/createEvent.ts
@@ -3,7 +3,11 @@ import { ProgressEventPolyfill } from '../polyfills/ProgressEventPolyfill'
 
 const SUPPORTS_PROGRESS_EVENT = typeof ProgressEvent !== 'undefined'
 
-export function createEvent(options: any, target: any, type: string) {
+export function createEvent(
+  target: XMLHttpRequest,
+  type: string,
+  init?: ProgressEventInit
+): EventPolyfill {
   const progressEvents = [
     'error',
     'progress',
@@ -25,8 +29,8 @@ export function createEvent(options: any, target: any, type: string) {
   const event = progressEvents.includes(type)
     ? new ProgressEventClass(type, {
         lengthComputable: true,
-        loaded: options?.loaded || 0,
-        total: options?.total || 0,
+        loaded: init?.loaded || 0,
+        total: init?.total || 0,
       })
     : new EventPolyfill(type, {
         target,

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.browser.runtime.js
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.browser.runtime.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai'
+import { createInterceptor } from 'node-request-interceptor'
+import { interceptXMLHttpRequest } from 'node-request-interceptor/lib/interceptors/XMLHttpRequest'
+
+const interceptor = createInterceptor({
+  modules: [interceptXMLHttpRequest],
+  resolver(request, ref) {
+    // Assert isomorphic request.
+    expect(request.method).to.equal(expected.method)
+    expect(request.url).to.be.instanceOf(URL)
+    expect(request.url.toString()).to.equal(expected.url)
+    Object.entries(expected.query || {}).forEach(([name, value]) => {
+      expect(request.url.searchParams.get(name)).to.equal(value)
+    })
+    Object.entries(expected.headers || {}).forEach(([name, value]) => {
+      expect(request.headers).to.have.property(name, value)
+    })
+    expect(request.body).to.equal(expected.body)
+
+    // Assert request reference.
+    expect(ref).to.be.instanceOf(XMLHttpRequest)
+    expect(ref.method).to.equal(expected.method)
+    expect(ref.url).to.equal(expected.url)
+  },
+})
+
+interceptor.apply()

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.browser.test.ts
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.browser.test.ts
@@ -1,0 +1,84 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { createServer, ServerApi } from '@open-draft/test-server'
+import { RequestHandler } from 'express'
+import { createBrowserXMLHttpRequest } from '../../helpers'
+
+let server: ServerApi
+
+function prepareRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'XMLHttpRequest.browser.runtime.js'),
+  })
+}
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    const requestHandler: RequestHandler = (req, res) => {
+      res.status(200).send('user-body').end()
+    }
+
+    app.get('/user', requestHandler)
+    app.post('/user', requestHandler)
+  })
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+test('intercepts an HTTP GET request', async () => {
+  const context = await prepareRuntime()
+  const request = createBrowserXMLHttpRequest(context)
+  const url = server.http.makeUrl('/user')
+  const response = await request(
+    'GET',
+    url,
+    {
+      'x-request-header': 'yes',
+    },
+    undefined,
+    {
+      expected: {
+        method: 'GET',
+        url,
+        headers: {
+          'x-request-header': 'yes',
+        },
+        body: '',
+      },
+    }
+  )
+
+  expect(response).toHaveProperty('status', 200)
+  expect(response).toHaveProperty('statusText', 'OK')
+  expect(response).toHaveProperty('body', 'user-body')
+})
+
+test('intercepts an HTTP POST request', async () => {
+  const context = await prepareRuntime()
+  const request = createBrowserXMLHttpRequest(context)
+  const url = server.http.makeUrl('/user')
+  const response = await request(
+    'POST',
+    url,
+    {
+      'x-request-header': 'yes',
+    },
+    JSON.stringify({ user: 'john' }),
+    {
+      expected: {
+        method: 'POST',
+        url,
+        headers: {
+          'x-request-header': 'yes',
+        },
+        body: JSON.stringify({ user: 'john' }),
+      },
+    }
+  )
+
+  expect(response).toHaveProperty('status', 200)
+  expect(response).toHaveProperty('statusText', 'OK')
+  expect(response).toHaveProperty('body', 'user-body')
+})

--- a/test/response/xhr.browser.runtime.js
+++ b/test/response/xhr.browser.runtime.js
@@ -1,0 +1,22 @@
+import { createInterceptor } from 'node-request-interceptor'
+import { interceptXMLHttpRequest } from 'node-request-interceptor/lib/interceptors/XMLHttpRequest'
+
+window.interceptor = createInterceptor({
+  modules: [interceptXMLHttpRequest],
+  resolver(request) {
+    const { serverHttpUrl, serverHttpsUrl } = window
+
+    if ([serverHttpUrl, serverHttpsUrl].includes(request.url.href)) {
+      return {
+        status: 201,
+        statusText: 'Created',
+        headers: {
+          'Content-Type': 'application/hal+json',
+        },
+        body: JSON.stringify({ mocked: true }),
+      }
+    }
+  },
+})
+
+window.interceptor.apply()

--- a/test/response/xhr.browser.test.ts
+++ b/test/response/xhr.browser.test.ts
@@ -1,0 +1,104 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { createServer, ServerApi } from '@open-draft/test-server'
+import { createBrowserXMLHttpRequest } from '../helpers'
+import { InterceptorApi } from '../../src'
+
+declare namespace window {
+  export const interceptor: InterceptorApi
+  export let serverHttpUrl: string
+  export let serverHttpsUrl: string
+}
+
+let server: ServerApi
+
+async function prepareRuntime() {
+  const scenario = await pageWith({
+    example: path.resolve(__dirname, 'xhr.browser.runtime.js'),
+  })
+
+  await scenario.page.evaluate((httpUrl) => {
+    window.serverHttpUrl = httpUrl
+  }, server.http.makeUrl('/'))
+
+  await scenario.page.evaluate((httpsUrl) => {
+    window.serverHttpsUrl = httpsUrl
+  }, server.https.makeUrl('/'))
+
+  return scenario
+}
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.get('/', (req, res) => {
+      res.status(200).json({ route: '/' })
+    })
+    app.get('/get', (req, res) => {
+      res.status(200).json({ route: '/get' })
+    })
+  })
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+test('responds to an HTTP request handled in the resolver', async () => {
+  const scenario = await prepareRuntime()
+  const request = createBrowserXMLHttpRequest(scenario)
+  const response = await request('GET', server.http.makeUrl('/'))
+
+  expect(response).toHaveProperty('status', 201)
+  expect(response).toHaveProperty('statusText', 'Created')
+  expect(response).toHaveProperty(
+    'headers',
+    'Content-Type: application/hal+json\r\n'
+  )
+  expect(response).toHaveProperty('body', JSON.stringify({ mocked: true }))
+})
+
+test('responds to an HTTPS request handled in the resolver', async () => {
+  const scenario = await prepareRuntime()
+  const request = createBrowserXMLHttpRequest(scenario)
+  const response = await request('GET', server.https.makeUrl('/'))
+
+  expect(response).toHaveProperty('status', 201)
+  expect(response).toHaveProperty('statusText', 'Created')
+  expect(response).toHaveProperty(
+    'headers',
+    'Content-Type: application/hal+json\r\n'
+  )
+  expect(response).toHaveProperty('body', JSON.stringify({ mocked: true }))
+})
+
+test('bypasses a request not handled in the resolver', async () => {
+  const scenario = await prepareRuntime()
+  const request = createBrowserXMLHttpRequest(scenario)
+  const response = await request('GET', server.http.makeUrl('/get'))
+
+  expect(response).toHaveProperty('status', 200)
+  expect(response).toHaveProperty('statusText', 'OK')
+  expect(response).toHaveProperty('body', JSON.stringify({ route: '/get' }))
+})
+
+test('bypasses any request when the interceptor is restored', async () => {
+  const scenario = await prepareRuntime()
+  const request = createBrowserXMLHttpRequest(scenario)
+
+  await scenario.page.evaluate(() => {
+    window.interceptor.restore()
+  })
+
+  const firstResponse = await request('GET', server.http.makeUrl('/'))
+  expect(firstResponse).toHaveProperty('status', 200)
+  expect(firstResponse).toHaveProperty('statusText', 'OK')
+  expect(firstResponse).toHaveProperty('body', JSON.stringify({ route: '/' }))
+
+  const secondResponse = await request('GET', server.http.makeUrl('/get'))
+  expect(secondResponse).toHaveProperty('status', 200)
+  expect(secondResponse).toHaveProperty('statusText', 'OK')
+  expect(secondResponse).toHaveProperty(
+    'body',
+    JSON.stringify({ route: '/get' })
+  )
+})


### PR DESCRIPTION
## GitHub

- Follow-up to #93 

## Changes

- Adds in-browser tests for XMLHttpRequest interception and response mocking.
- Uses the env-agnostic `bufferFrom` utility instead of `Buffer.from()` that's available only in Node.js.
- Adds tests for the `createEvent` function.

We don't need to use the native `window.Event` because it forbids setting the `target`, which in the case of `XMLHttpRequestOverride` should be the overridden class. That's one of the reasons we have the `EventPolyfill` because it allows setting a custom event target in the class constructor. 