### PR TITLE
fix(XMLHttpRequest): reorder trigger "loadstart" upon mocked response…

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -263,6 +263,9 @@ export const createXMLHttpRequestOverride = (
           if (mockedResponse) {
             debug('received mocked response', mockedResponse)
 
+            // Trigger a loadstart event to indicate the initialization of the fetch
+            this.trigger('loadstart')
+            
             this.status = mockedResponse.status || 200
             this.statusText = mockedResponse.statusText || 'OK'
             this._responseHeaders = mockedResponse.headers
@@ -301,9 +304,10 @@ export const createXMLHttpRequestOverride = (
              * @see https://github.com/mswjs/node-request-interceptor/issues/13
              */
             this.readyState = this.DONE
-
-            this.trigger('loadstart')
+            
+            // Trigger a load event to indicate the fetch has succeeded
             this.trigger('load')
+            //Trigger a loadend event to indicate the fetch has completed 
             this.trigger('loadend')
 
             observer.emit('response', req, {

--- a/test/compliance/XMLHttpRequest/events-order.test.ts
+++ b/test/compliance/XMLHttpRequest/events-order.test.ts
@@ -1,0 +1,152 @@
+import { ServerApi, createServer } from '@open-draft/test-server'
+import { createInterceptor } from '../../../src'
+import { interceptXMLHttpRequest } from '../../../src/interceptors/XMLHttpRequest'
+import { createXMLHttpRequest } from '../../helpers'
+
+type EventPool = [string, number][]
+
+let server: ServerApi
+const interceptor = createInterceptor({
+  modules: [interceptXMLHttpRequest],
+  resolver(request) {
+    switch (request.url.pathname) {
+      case '/user': {
+        return {
+          status: 200,
+        }
+      }
+
+      case '/numbers-mock': {
+        return {
+          status: 200,
+          body: JSON.stringify([1, 2, 3]),
+        }
+      }
+    }
+  },
+})
+
+function spyOnEvents(request: XMLHttpRequest, pool: EventPool) {
+  function listener(this: XMLHttpRequest, event: Event) {
+    // console.log(
+    //   'called listener "%s" (%d)\n%s',
+    //   event.type,
+    //   this.readyState,
+    //   new Error().stack
+    // )
+    pool.push([event.type, this.readyState])
+  }
+  request.addEventListener('readystatechange', listener)
+  request.addEventListener('loadstart', listener)
+  request.addEventListener('progress', listener)
+  request.addEventListener('timeout', listener)
+  request.addEventListener('load', listener)
+  request.addEventListener('loadend', listener)
+  request.addEventListener('abort', listener)
+  request.addEventListener('error', listener)
+}
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.get('/', (req, res) => {
+      res.status(200).end()
+    })
+    app.get('/numbers', (req, res) => {
+      res.status(200).json([1, 2, 3])
+    })
+  })
+})
+
+afterEach(() => {
+  interceptor.restore()
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+test('emits correct events sequence for an unhandled request with no response body', async () => {
+  interceptor.apply()
+  const mockEvents: EventPool = []
+  const request = await createXMLHttpRequest((request) => {
+    request.open('GET', server.http.makeUrl())
+    spyOnEvents(request, mockEvents)
+  })
+
+  expect(mockEvents).toEqual([
+    ['loadstart', 1],
+    ['readystatechange', 2],
+    ['readystatechange', 4],
+    /**
+     * @note XMLHttpRequest polyfill from JSDOM dispatches the `readystatechange` listener.
+     * XMLHttpRequest override also dispatches the `readystatechange` listener for the original
+     * request explicitly to it never hangs. This results in the listener being called twice.
+     */
+    ['readystatechange', 4],
+    ['load', 4],
+    ['loadend', 4],
+  ])
+  expect(request.readyState).toBe(4)
+})
+
+test('emits correct events sequence for a handled request with no response body', async () => {
+  interceptor.apply()
+  const mockEvents: EventPool = []
+  const request = await createXMLHttpRequest((request) => {
+    request.open('GET', server.http.makeUrl('/user'))
+    spyOnEvents(request, mockEvents)
+  })
+
+  expect(mockEvents).toEqual([
+    ['loadstart', 1],
+    ['readystatechange', 2],
+    ['readystatechange', 4],
+    ['load', 4],
+    ['loadend', 4],
+  ])
+  expect(request.readyState).toBe(4)
+})
+
+test('emits correct events sequence for an unhandled request with a response body', async () => {
+  interceptor.apply()
+  const mockEvents: EventPool = []
+  const request = await createXMLHttpRequest((request) => {
+    request.open('GET', server.http.makeUrl('/numbers'))
+    spyOnEvents(request, mockEvents)
+  })
+
+  expect(mockEvents).toEqual([
+    ['loadstart', 1],
+    ['readystatechange', 2],
+    ['readystatechange', 3],
+    ['progress', 3],
+    ['readystatechange', 4],
+    /**
+     * @note The same issue with the `readystatechange` callback being called twice.
+     */
+    ['readystatechange', 4],
+    ['load', 4],
+    ['loadend', 4],
+  ])
+  expect(request.readyState).toBe(4)
+})
+
+test('emits correct events sequence for a handled request with a response body', async () => {
+  interceptor.apply()
+  const mockEvents: EventPool = []
+  const request = await createXMLHttpRequest((request) => {
+    request.open('GET', server.http.makeUrl('/numbers-mock'))
+    spyOnEvents(request, mockEvents)
+  })
+
+  expect(mockEvents).toEqual([
+    ['loadstart', 1],
+    ['readystatechange', 2],
+    ['readystatechange', 3],
+    ['progress', 3],
+    ['readystatechange', 4],
+    ['load', 4],
+    ['loadend', 4],
+  ])
+  expect(request.readyState).toBe(4)
+})


### PR DESCRIPTION
## GitHub

As stated in #76, some events are grouped together _(loadstart, load, loadend)_ which is not a valid flow of an XHR request. This small PR reorders the events to the specification to guarantee compatibility for the users as @kettanaito states.

## Changes: 

- Moves up the loadstart event so that it's dispatched as soon it handles a mocked response.
Based on the [Events summary](https://xhr.spec.whatwg.org/#event-xhr-loadstart)
- Fixes #76 