### PR TITLE
Renames the package to "@mswjs/interceptors"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-request-interceptor",
-  "description": "Low-level HTTP/HTTPS/XHR request interception library for Node.js",
+  "name": "@mswjs/interceptors",
+  "description": "Low-level HTTP/HTTPS/XHR/fetch request interception library.",
   "version": "0.6.3",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -23,7 +23,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mswjs/node-request-interceptor"
+    "url": "https://github.com/mswjs/interceptors"
   },
   "devDependencies": {
     "@open-draft/test-server": "^0.2.3",


### PR DESCRIPTION
## Motivation

This package is no longer Node.js-specific after the introduction of the `fetch` interception (#93). The "node" part in the name may be confusing. 